### PR TITLE
Docs/debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ To compile, some software packages are required. These can be installed by runni
 ```shell
 sudo apt install cmake
 sudo apt install g++
+```
+
+For the python postprocessors the following is also required
+
+```shell
 sudo apt install python3-pip
 sudo apt install python3.12-venv
 ```
@@ -61,6 +66,12 @@ make
 ```
 
 This will build the default target, which includes the all the example applications.
+
+Before installing make sure the target directory is writable.
+
+```shell
+sudo chmod 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+```
 
 To install the generated postprocessor examples to the default postprocessors folder:
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ These applications can be compiled on any architecture natively in a Linux envir
 
 To compile, some software packages are required. These can be installed by running:
 
-- sudo apt install cmake
-- sudo apt install g++
+```shell
+sudo apt install cmake
+sudo apt install g++
+sudo apt install python3-pip
+sudo apt install python3.12-venv
+```
 
 Also make sure that all of these are accessible from PATH.
 
@@ -33,19 +37,26 @@ This project is CMake based, and all its modules can be compiled or gathered wit
 
 Create and enter build directory:
 
+```shell
+mkdir -p build && cd build
 ```
-mkdir build && cd build
+
+Set up a python virtual environment (needed on recent ubuntu servers) in the newly created build directory
+
+```shell
+python3 -m venv integrationsdk
+source integrationsdk/bin/activate
 ```
 
 Set up CMake configuration:
 
-```
+```shell
 cmake ..
 ```
 
 Build all targets:
 
-```
+```shell
 make
 ```
 
@@ -53,13 +64,13 @@ This will build the default target, which includes the all the example applicati
 
 To install the generated postprocessor examples to the default postprocessors folder:
 
-```
+```shell
 cmake --build . --target install
 ```
 
 Finally, to (re)load your new postprocessor, make sure to restart the NX Server with:
 
-```
+```shell
 sudo service networkoptix-metavms-mediaserver restart
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
 NX Integration SDK
-=========================
+==================
 
 The NX Integration SDK provides tools and examples for clients to create applications which seamlessly integrates with the NX software stack.
 
 See the subdirectories for further documentation.
 
-## Requirements
+# Requirements
 
-### To Clone
+## Download the integration SDK
+
+You probably have the integration SDK already if you're looking at this readme, the command to get the full integration SDK is as follows:
+
+```shell
+git clone https://github.com/scailable/sclbl-integration-sdk.git --recurse-submodules
+```
+
+If you have downloaded the sdk previously, you can also update to the latest version of the integration SDK while in the directory of the downloaded git repository.
+
+```shell
+git pull --recurse-submodules
+```
 
 The repository should be cloned with `--recurse-submodules`.
 
-### To Compile
+## Requirements to compile the postprocessors
 
 These applications can be compiled on any architecture natively in a Linux environment.
 
@@ -29,23 +41,32 @@ sudo apt install python3-pip
 sudo apt install python3.12-venv
 ```
 
-Also make sure that all of these are accessible from PATH.
-
-### To run
+## Requirements to run the postprocessors
 
 These applications can be run on any platform on which they can be compiled.
 
+# How to use
+
 ## Getting Started
 
-This project is CMake based, and all its modules can be compiled or gathered with CMake commands. To compile manually:
+This project is CMake based, and all its modules can be compiled or gathered with CMake commands.
 
-Create and enter build directory:
+Because the different postprocessors must be compiled for each hardware architecture this repository does not include pre-built binaries. All processors can be compiled manually.
+
+Change into the directory created for the project if you're not already there.
 
 ```shell
-mkdir -p build && cd build
+cd sclbl-integration-sdk/
 ```
 
-For the python postprocessors you need to set up a python virtual environment (especially needed on recent ubuntu servers) in the newly created build directory
+Prepare the *build* directory in the project directory, and switch to the build directory.
+
+```shell
+mkdir -p build
+cd build
+```
+
+Set up a python virtual environment in the newly created build directory (on recent ubuntu servers this is required).
 
 ```shell
 python3 -m venv integrationsdk
@@ -66,6 +87,8 @@ make
 
 This will build the default target, which includes the all the example applications that are active in the `CMakeLists.txt`.
 
+It is possible to only run specific examples, refer to the readme files in the subdirectories of those examples for specific instructions.
+
 ## Install the postprocessors
 
 Before installing make sure the target directory is writable.
@@ -78,6 +101,52 @@ To install the generated postprocessor examples to the default postprocessors fo
 
 ```shell
 cmake --build . --target install
+```
+
+## Defining the postprocessor
+
+Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/external_postprocessors.json` and add the details of your postprocessors to the root object of that file. For example the following file enables *all* python based postprocessors:
+
+```json
+{
+    "externalPostprocessors": [
+        {
+            "Name":"EI-Upload-Postprocessor",
+            "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-edgeimpulse-example",
+            "SocketPath":"/tmp/python-edgeimpulse-postprocessor.sock",
+            "ReceiveInputTensor": 1,
+            "RunLast": false,
+            "NoResponse": true
+        },
+        {
+            "Name":"Example-Postprocessor",
+            "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-example",
+            "SocketPath":"/tmp/python-example-postprocessor.sock",
+            "ReceiveInputTensor": 0
+        },
+        {
+            "Name":"Image-Postprocessor",
+            "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-image-example",
+            "SocketPath":"/tmp/python-image-postprocessor.sock",
+            "ReceiveInputTensor": 1
+        },
+        {
+            "Name":"NoResponse-Postprocessor",
+            "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-noresponse-example",
+            "SocketPath":"/tmp/python-noresponse-postprocessor.sock",
+            "ReceiveInputTensor": 0,
+            "ReceiveBinaryData": false,
+            "NoResponse": true
+        },
+        {
+            "Name":"Cloud-Inference-Postprocessor",
+            "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-cloud-inference-example",
+            "SocketPath":"/tmp/python-cloud-inference-postprocessor.sock",
+            "ReceiveInputTensor": 1
+        }
+
+    ]
+}
 ```
 
 ## Restarting the server
@@ -97,71 +166,72 @@ sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
-## Licence
 
-Copyright 2024, Network Optix, All rights reserved.
-
-## Directory structure
+# Directory structure
 
 ```
 .
 ├── CMakeLists.txt
 ├── README.md
 ├── postprocessor-c-example
-│   ├── CMakeLists.txt
-│   ├── README.md
-│   ├── deps
-│   │   ├── mpack.c
-│   │   ├── mpack.h
-│   │   └── nxai_data_utils.h
-│   └── src
-│       ├── main.c
-│       └── nxai_data_utils.c
+│   ├── CMakeLists.txt
+│   ├── README.md
+│   ├── deps
+│   │   ├── mpack.c
+│   │   ├── mpack.h
+│   │   └── nxai_data_utils.h
+│   └── src
+│       ├── main.c
+│       └── nxai_data_utils.c
 ├── postprocessor-c-image-example
-│   ├── CMakeLists.txt
-│   ├── README.md
-│   ├── deps
-│   │   ├── mpack.c
-│   │   ├── mpack.h
-│   │   └── nxai_data_utils.h
-│   └── src
-│       ├── main.c
-│       └── nxai_data_utils.c
+│   ├── CMakeLists.txt
+│   ├── README.md
+│   ├── deps
+│   │   ├── mpack.c
+│   │   ├── mpack.h
+│   │   └── nxai_data_utils.h
+│   └── src
+│       ├── main.c
+│       └── nxai_data_utils.c
 ├── postprocessor-c-raw-example
-│   ├── CMakeLists.txt
-│   ├── README.md
-│   ├── deps
-│   │   ├── mpack.c
-│   │   ├── mpack.h
-│   │   └── nxai_data_utils.h
-│   └── src
-│       ├── main.c
-│       └── nxai_data_utils.c
+│   ├── CMakeLists.txt
+│   ├── README.md
+│   ├── deps
+│   │   ├── mpack.c
+│   │   ├── mpack.h
+│   │   └── nxai_data_utils.h
+│   └── src
+│       ├── main.c
+│       └── nxai_data_utils.c
 ├── postprocessor-cloud-inference-example
-│   ├── CMakeLists.txt
-│   ├── README.md
-│   ├── aws_utils.py
-│   ├── postprocessor-cloud-inference-example.py
-│   └── requirements.txt
+│   ├── CMakeLists.txt
+│   ├── README.md
+│   ├── aws_utils.py
+│   ├── postprocessor-cloud-inference-example.py
+│   └── requirements.txt
 ├── postprocessor-python-edgeimpulse-example
-│   ├── CMakeLists.txt
-│   ├── README.md
-│   ├── postprocessor-python-edgeimpulse-example.py
-│   └── requirements.txt
+│   ├── CMakeLists.txt
+│   ├── README.md
+│   ├── postprocessor-python-edgeimpulse-example.py
+│   └── requirements.txt
 ├── postprocessor-python-example
-│   ├── CMakeLists.txt
-│   ├── README.md
-│   ├── postprocessor-python-example.py
-│   └── requirements.txt
+│   ├── CMakeLists.txt
+│   ├── README.md
+│   ├── postprocessor-python-example.py
+│   └── requirements.txt
 ├── postprocessor-python-image-example
-│   ├── CMakeLists.txt
-│   ├── README.md
-│   ├── postprocessor-python-image-example.py
-│   └── requirements.txt
+│   ├── CMakeLists.txt
+│   ├── README.md
+│   ├── postprocessor-python-image-example.py
+│   └── requirements.txt
 ├── postprocessor-python-noresponse-example
-│   ├── CMakeLists.txt
-│   ├── README.md
-│   ├── postprocessor-python-noresponse-example.py
-│   └── requirements.txt
+│   ├── CMakeLists.txt
+│   ├── README.md
+│   ├── postprocessor-python-noresponse-example.py
+│   └── requirements.txt
 └── sclbl-utilities
 ```
+
+# Licence
+
+Copyright 2024, Network Optix, All rights reserved.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Also make sure that all of these are accessible from PATH.
 
 These applications can be run on any platform on which they can be compiled.
 
-
 ## Getting Started
 
 This project is CMake based, and all its modules can be compiled or gathered with CMake commands. To compile manually:
@@ -46,7 +45,7 @@ Create and enter build directory:
 mkdir -p build && cd build
 ```
 
-Set up a python virtual environment (needed on recent ubuntu servers) in the newly created build directory
+For the python postprocessors you need to set up a python virtual environment (especially needed on recent ubuntu servers) in the newly created build directory
 
 ```shell
 python3 -m venv integrationsdk
@@ -65,7 +64,9 @@ Build all targets:
 make
 ```
 
-This will build the default target, which includes the all the example applications.
+This will build the default target, which includes the all the example applications that are active in the `CMakeLists.txt`.
+
+## Install the postprocessors
 
 Before installing make sure the target directory is writable.
 
@@ -79,12 +80,23 @@ To install the generated postprocessor examples to the default postprocessors fo
 cmake --build . --target install
 ```
 
+## Restarting the server
+
 Finally, to (re)load your new postprocessor, make sure to restart the NX Server with:
 
 ```shell
 sudo service networkoptix-metavms-mediaserver restart
 ```
 
+You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
+
+```
+sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+```
+
+## Selecting to the postprocessor
+
+If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
 ## Licence
 
 Copyright 2024, Network Optix, All rights reserved.

--- a/postprocessor-c-example/README.md
+++ b/postprocessor-c-example/README.md
@@ -74,7 +74,6 @@ The socket path is always given as the first command line argument when the appl
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
 
-
 # Licence
 
 Copyright 2024, Network Optix, All rights reserved.

--- a/postprocessor-c-image-example/README.md
+++ b/postprocessor-c-image-example/README.md
@@ -43,7 +43,6 @@ The image header message contains fields indicating information about the image 
 {
     "Width": <Width>,
     "Height": <Height>,
-    "Height": <Height>,
     "SHMKey": <SHM Key>,
     "SHMID": <SHM ID>
 }

--- a/postprocessor-cloud-inference-example/CMakeLists.txt
+++ b/postprocessor-cloud-inference-example/CMakeLists.txt
@@ -3,5 +3,5 @@ add_custom_target(postprocessor-cloud-inference-example ALL
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND pip install -r ../sclbl-utilities/python-utilities/requirements.txt
     COMMAND pip install -r requirements.txt
-    COMMAND pyinstaller postprocessor-cloud-inference-example.py --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
+    COMMAND pyinstaller postprocessor-cloud-inference-example.py --clean --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
 )

--- a/postprocessor-cloud-inference-example/README.md
+++ b/postprocessor-cloud-inference-example/README.md
@@ -53,7 +53,7 @@ Also set a region for AWS in `~/.aws/config`
 region=us-east-1
 ```
 
-You can configure other settings in the configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.cloud-inference.ini`:
+You can configure other settings in the [configuration file](plugin.cloud-inference.ini.example) at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.cloud-inference.ini`:
 
 ```ini
 [common]

--- a/postprocessor-cloud-inference-example/README.md
+++ b/postprocessor-cloud-inference-example/README.md
@@ -15,17 +15,12 @@ The workflow is as follows:
 
 ## Requirements
 
-For this example to work, you need to ensure that you have assigned the Face locator model on your edge device from the Nx AI Cloud.   
-Additionally, you need to set your AWS credential keys in the [aws_utils.py](aws_utils.py) file.
-```python
-session = boto3.Session(
-    aws_access_key_id='',  # Specify your access key
-    aws_secret_access_key='', # Specify your secret key
-    region_name='us-east-1'  # Specify your region
-)
-```
+For this example to work, you need to ensure that you have assigned the Face locator model on your edge device from the Nx AI Cloud. 
+
+You also need an AWS account and the associated Access Key and Access Secret.
 
 # How To Use
+
 
 Once compiled, copy the executable to an accessible directory. A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
 
@@ -33,6 +28,24 @@ It's a good idea to make sure the application and settings file you add is reada
 
 ```
 sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors
+```
+
+## Local configuration
+
+You need to set your AWS credential keys in the configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.cloud-inference.ini`:
+
+```ini
+[common]
+debug_level=DEBUG
+[cloud]
+# Add your own AWS access key
+aws_access_key_id=your_aws_access_key
+# Add your own AWS access secret
+aws_secret_access_key=your_aws_access_secret
+# Add your AWS region
+region_name=us-east-1
+[inference]
+image_path=/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/face.png
 ```
 
 ## Defining the postprocessor
@@ -43,9 +56,9 @@ Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugin
 {
     "externalPostprocessors": [
         {
-            "Name":"Example-Postprocessor",
+            "Name":"Cloud-Inference-Postprocessor",
             "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-cloud-inference-example",
-            "SocketPath":"/tmp/example-postprocessor.sock",
+            "SocketPath":"/tmp/python-cloud-inference-postprocessor.sock",
             "ReceiveInputTensor": 1
         }
     ]
@@ -57,6 +70,24 @@ This tells the Edge AI Manager about the postprocessor:
 - **Command** defines how to start the postprocessor
 - **SocketPath** tells the AI Manager where to send data to so the external postprocessor will receive it
 - **ReceiveInputTensor** tells the AI Manager if this postprocessor expects information to access the raw input tensor data
+
+## Restarting the server
+
+Finally, to (re)load your new postprocessor, make sure to restart the NX Server with:
+
+```shell
+sudo service networkoptix-metavms-mediaserver restart
+```
+
+You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
+
+```
+sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+```
+
+## Selecting to the postprocessor
+
+If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
 
 # Licence
 

--- a/postprocessor-cloud-inference-example/README.md
+++ b/postprocessor-cloud-inference-example/README.md
@@ -21,7 +21,6 @@ You also need an AWS account and the associated Access Key and Access Secret.
 
 # How To Use
 
-
 Once compiled, copy the executable to an accessible directory. A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
 
 It's a good idea to make sure the application and settings file you add is readable and executable by the NXAI Edge AI Manager. This can be achieved by running:
@@ -32,18 +31,19 @@ sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/
 
 ## Local configuration
 
-You need to set your AWS credential keys in the configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.cloud-inference.ini`:
+You need to set your AWS credential keys in the configuration file at `~/.aws/credentials`:
+
+```ini
+[default]
+aws_access_key_id=acced_key
+aws_secret_access_key=secret_access_key
+```
+
+You can configure other settings in the configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.cloud-inference.ini`:
 
 ```ini
 [common]
 debug_level=DEBUG
-[cloud]
-# Add your own AWS access key
-aws_access_key_id=your_aws_access_key
-# Add your own AWS access secret
-aws_secret_access_key=your_aws_access_secret
-# Add your AWS region
-region_name=us-east-1
 [inference]
 image_path=/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/face.png
 ```

--- a/postprocessor-cloud-inference-example/README.md
+++ b/postprocessor-cloud-inference-example/README.md
@@ -17,7 +17,10 @@ The workflow is as follows:
 
 For this example to work, you need to ensure that you have assigned the Face locator model on your edge device from the Nx AI Cloud. 
 
-You also need an AWS account and the associated Access Key and Access Secret.
+You also need an AWS account and the associated Access Key and Access Secret. 
+Please refer to the amazon AWS documentation on how to get these keys.
+The user needs `AmazonRekognitionReadOnlyAccess` to use the features in this demo.
+Amazon usage charges may apply.
 
 # How To Use
 
@@ -31,12 +34,21 @@ sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/
 
 ## Local configuration
 
+There are two configuration files you need to set for Amazon AWS to run this demo. 
+
 You need to set your AWS credential keys in the configuration file at `~/.aws/credentials`:
 
 ```ini
 [default]
 aws_access_key_id=acced_key
 aws_secret_access_key=secret_access_key
+```
+
+Also set a region for AWS in `~/.aws/config`
+
+```ini
+[default]
+region=us-east-1
 ```
 
 You can configure other settings in the configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.cloud-inference.ini`:

--- a/postprocessor-cloud-inference-example/README.md
+++ b/postprocessor-cloud-inference-example/README.md
@@ -1,11 +1,7 @@
 Cloud inference with the Nx AI Manager
 =========================
 
-> Before delving into this example, please review the [Python example](../postprocessor-python-image-example/) to understand how to configure the post-processing
-
-# Overview
-
-This example is meant to be used to illustrate how the Nx AI Manager allows the user to perform additional data analysis on the stream logic on a cloud machine.   
+This example is meant to be used to illustrate how the Nx AI Manager allows the user to perform additional data analysis on the stream logic on a cloud machine.
 For the sake of example, the AWS Rekognition API was used to perform age, gender and emotion classification on faces detected by the AI Manager.
 
 The workflow is as follows:
@@ -13,26 +9,32 @@ The workflow is as follows:
 2. When the model inference is accomplished, the AI Manager sends its output to the Python external post-processor that sends a request (per detected face) to AWS Rekognition, and waits for response.
 3. The post-processor overwrites the category of the detected object (ie. "face") to a more insightful one, such as: "A male in his 30s feeling happy", and sends back the result to Nx to visualize it.
 
-## Requirements
+# Requirements
 
-For this example to work, you need to ensure that you have assigned the Face locator model on your edge device from the Nx AI Cloud. 
+For this example to work, you need to assign the Face locator model to your camera device. 
 
-You also need an AWS account and the associated Access Key and Access Secret. 
-Please refer to the amazon AWS documentation on how to get these keys.
+You also need an AWS account and the associated Access Key and Access Secret. Refer to the amazon AWS documentation on how to get these keys.
 The user needs `AmazonRekognitionReadOnlyAccess` to use the features in this demo.
-Amazon usage charges may apply.
 
-# How To Use
+Amazon usage charges may apply, but it is possible to use the free tier to test this.
 
-Once compiled, copy the executable to an accessible directory. A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
+# How to use
 
-It's a good idea to make sure the application and settings file you add is readable and executable by the NXAI Edge AI Manager. This can be achieved by running:
+## Download the integration SDK
 
+You probably have the integration SDK already if you're looking at this readme, the command to get the full integration SDK is as follows:
+
+```shell
+git clone https://github.com/scailable/sclbl-integration-sdk.git --recurse-submodules
 ```
-sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors
+
+If you have downloaded the sdk previously, you can also update to the latest version of the integration SDK while in the directory of the downloaded git repository.
+
+```shell
+git pull --recurse-submodules
 ```
 
-## Local configuration
+## Configuration of example postprocessor
 
 There are two configuration files you need to set for Amazon AWS to run this demo. 
 
@@ -58,6 +60,96 @@ You can configure other settings in the configuration file at `/opt/networkoptix
 debug_level=DEBUG
 [inference]
 image_path=/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/face.png
+```
+
+## Preparation of dependencies
+
+Install the needed dependencies
+
+```shell
+sudo apt install cmake
+sudo apt install g++
+sudo apt install python3-pip
+sudo apt install python3.12-venv
+```
+
+Change into the directory created for the project if you're not already there.
+
+```shell
+cd sclbl-integration-sdk/
+```
+
+Prepare the *build* directory in the project directory, and switch to the build directory.
+
+```shell
+mkdir -p build
+cd build
+```
+
+Set up a python virtual environment in the newly created build directory (on recent ubuntu servers this is required).
+
+```shell
+python3 -m venv integrationsdk
+source integrationsdk/bin/activate
+```
+
+## (optionally) Remove other postprocessors for compilation
+
+Edit the `CMakelist.txt` to disable all but the external postprocessor.
+
+```shell
+nano ../CMakeLists.txt
+```
+
+It should look similar to this
+
+```shell
+cmake_minimum_required(VERSION 3.10.2)
+
+project(sclbl-integration-examples)
+
+# Add Scailable C Utilities for all subprojects
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sclbl-utilities)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/sclbl-utilities/include)
+
+# Add Cloud Inference Postprocessor Python project
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/postprocessor-cloud-inference-example)
+
+# # Add installation option
+install(TARGETS
+    DESTINATION /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+)
+install(PROGRAMS
+    ${CMAKE_CURRENT_BINARY_DIR}/postprocessor-cloud-inference-example/postprocessor-cloud-inference-example
+    DESTINATION /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+)
+```
+
+## Compile the postprocessor in python
+
+Build the postprocessor, while in the created *build* directory. This may take a while, depending on the speed of your system.
+
+```shell
+cmake ..
+make
+```
+
+## Install the postprocessor
+
+Once compiled, copy the executable to an accessible directory.
+
+A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
+
+The application and settings files you add must be readable and executable by the NX AI Edge AI Manager. This can be achieved by running:
+
+```
+sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors
+```
+
+Install the postprocessor automatically with the cmake command, also from within the *build* directory.
+
+```shell
+cmake --build . --target install
 ```
 
 ## Defining the postprocessor
@@ -93,13 +185,21 @@ sudo service networkoptix-metavms-mediaserver restart
 
 You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
 
-```
+```shell
 sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
 ```
 
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
+
+## Output logging
+
+There is an output log where the uploads can be tracked in real time from the server.
+
+```shell
+tail -f /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.cloud-inference.log
+```
 
 # Licence
 

--- a/postprocessor-cloud-inference-example/aws_utils.py
+++ b/postprocessor-cloud-inference-example/aws_utils.py
@@ -2,19 +2,22 @@ import boto3
 
 rekognition_client = None
 
-def create_session(aws_access_key_id, aws_secret_access_key, region_name, logger, rekognition_client = None):
+def create_session(logger, rekognition_client = None):
 
     logger.info("Creating session to AWS")
 
     try:
-        session = boto3.Session(
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            region_name=region_name
-        )
+        # create configuration in ~/.aws/credentials
+        #
+        # [default]
+        # aws_access_key_id=acced_key
+        # aws_secret_access_key=secret_access_key
+
+        session = boto3.Session()
 
         new_rekognition_client = session.client('rekognition')
-        logger.info("Created session to AWS")
+
+        logger.info("Created session rekognition to AWS")
 
     except Exception as e:
         logger.error(f"Error: {e}")
@@ -22,12 +25,12 @@ def create_session(aws_access_key_id, aws_secret_access_key, region_name, logger
     return new_rekognition_client
 
 
-def classify_faces(image_path, aws_access_key_id, aws_secret_access_key, region_name, logger):
+def classify_faces(image_path, logger):
 
     global rekognition_client
 
     if rekognition_client is None:
-        rekognition_client = create_session(aws_access_key_id, aws_secret_access_key, region_name, logger)
+        rekognition_client = create_session(logger)
 
     try:
         with open(image_path, 'rb') as image:

--- a/postprocessor-cloud-inference-example/aws_utils.py
+++ b/postprocessor-cloud-inference-example/aws_utils.py
@@ -2,6 +2,7 @@ import boto3
 
 rekognition_client = None
 
+
 def create_session(logger, rekognition_client = None):
 
     logger.info("Creating session to AWS")
@@ -12,6 +13,11 @@ def create_session(logger, rekognition_client = None):
         # [default]
         # aws_access_key_id=acced_key
         # aws_secret_access_key=secret_access_key
+        #
+        # and  create configuration in ~/.aws/config
+        #
+        # [default]
+        # region=us-east-1
 
         session = boto3.Session()
 
@@ -40,7 +46,12 @@ def classify_faces(image_path, logger):
                 },
                 Attributes=['GENDER', 'EMOTIONS', 'AGE_RANGE', 'SUNGLASSES', 'SMILE']
             )
+
         faces = response['FaceDetails']
+
+        facedescription = f', '.join(f"{k}:{v}" for k, v in faces.items())
+        logger.info(f"Description joined: {facedescription}")
+
         for face in faces:
             age_range = face['AgeRange']
             gender = face['Gender']
@@ -49,8 +60,12 @@ def classify_faces(image_path, logger):
             emotions = face['Emotions']
 
         age = age_to_word(age_range)
+
         his_her = 'his' if gender['Value'].lower() == 'male' else 'her'
         description = f"A {gender['Value'].lower()} in {his_her} {age} feeling {emotions[0]['Type'].lower()}."
+
+        logger.info(f"Description: {description}")
+
         return description
 
     except Exception as e:

--- a/postprocessor-cloud-inference-example/aws_utils.py
+++ b/postprocessor-cloud-inference-example/aws_utils.py
@@ -1,16 +1,34 @@
-import json
 import boto3
-from botocore.exceptions import ClientError
 
-session = boto3.Session(
-    aws_access_key_id='',  # Specify your access key
-    aws_secret_access_key='', # Specify your secret key
-    region_name='us-east-1'  # Specify your region
-)
+rekognition_client = None
 
-rekognition_client = session.client('rekognition')
+def create_session(aws_access_key_id, aws_secret_access_key, region_name, logger, rekognition_client = None):
 
-def classify_faces(image_path):
+    logger.info("Creating session to AWS")
+
+    try:
+        session = boto3.Session(
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            region_name=region_name
+        )
+
+        new_rekognition_client = session.client('rekognition')
+        logger.info("Created session to AWS")
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+
+    return new_rekognition_client
+
+
+def classify_faces(image_path, aws_access_key_id, aws_secret_access_key, region_name, logger):
+
+    global rekognition_client
+
+    if rekognition_client is None:
+        rekognition_client = create_session(aws_access_key_id, aws_secret_access_key, region_name, logger)
+
     try:
         with open(image_path, 'rb') as image:
             response = rekognition_client.detect_faces(
@@ -33,7 +51,7 @@ def classify_faces(image_path):
         return description
 
     except Exception as e:
-        print(f"Error: {e}")
+        logger.error(f"Error: {e}")
         return None
 
 

--- a/postprocessor-cloud-inference-example/plugin.cloud-inference.ini.example
+++ b/postprocessor-cloud-inference-example/plugin.cloud-inference.ini.example
@@ -1,0 +1,4 @@
+[common]
+debug_level=INFO
+[inference]
+image_path=/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/face.png

--- a/postprocessor-cloud-inference-example/postprocessor-cloud-inference-example.py
+++ b/postprocessor-cloud-inference-example/postprocessor-cloud-inference-example.py
@@ -192,21 +192,19 @@ if __name__ == "__main__":
     logger.info("Initializing cloud interference plugin")
     logger.debug("Input parameters: " + str(sys.argv))
 
-    # global rekognition_client
-    #
-    # if rekognition_client is None:
-    #     try:
-    #         rekognition_client = create_session(logger)
-    #     except Exception as e:
-    #         logger.error(e, exc_info=True)
-    #
-    # if rekognition_client is not None:
-    #     logging.debug('AWS Session started')
-    # else:
-    #     logging.error('AWS session failed')
-    #     exit()
+    global rekognition_client
 
-    exit(1)
+    if rekognition_client is None:
+        try:
+            rekognition_client = create_session(logger)
+        except Exception as e:
+            logger.error(e, exc_info=True)
+
+    if rekognition_client is not None:
+        logging.debug('AWS Session started')
+    else:
+        logging.error('AWS session failed')
+        exit()
 
     # Parse input arguments
     if len(sys.argv) > 1:

--- a/postprocessor-cloud-inference-example/postprocessor-cloud-inference-example.py
+++ b/postprocessor-cloud-inference-example/postprocessor-cloud-inference-example.py
@@ -38,7 +38,7 @@ Postprocessor_Name = "Cloud-Inference-Postprocessor"
 Postprocessor_Socket_Path = "/tmp/python-cloud-inference-postprocessor.sock"
 
 
-def parseImageFromSHM(shm_key: int, width: int, height: int, channels: int):
+def parse_image_from_shm(shm_key: int, width: int, height: int, channels: int):
     try:
         image_data = communication_utils.read_shm(shm_key)
         image_size = width * height * channels
@@ -65,7 +65,7 @@ def config():
         configuration.read(CONFIG_FILE)
 
         configured_log_level = configuration.get('common', 'debug_level', fallback = 'INFO')
-        setLogLevel(configured_log_level)
+        set_log_level(configured_log_level)
 
         for section in configuration.sections():
             logger.info('config section: ' + section)
@@ -83,14 +83,14 @@ def config():
     logger.debug('Read configuration done')
 
 
-def setLogLevel(level):
+def set_log_level(level):
     try:
         logger.setLevel(level)
     except Exception as e:
         logger.error(e, exc_info=True)
 
 
-def signalHandler(sig, _):
+def signal_handler(sig, _):
     logging.info("Received interrupt signal: " + str(sig))
     sys.exit(0)
 
@@ -127,7 +127,7 @@ def main():
         input_object = communication_utils.parseInferenceResults(input_message)
 
         image_header = msgpack.unpackb(image_header)
-        image_array = parseImageFromSHM(
+        image_array = parse_image_from_shm(
             image_header["SHMKey"],
             image_header["Width"],
             image_header["Height"],
@@ -208,7 +208,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]
     # Handle interrupt signals
-    signal.signal(signal.SIGINT, signalHandler)
+    signal.signal(signal.SIGINT, signal_handler)
     # Start program
     try:
         main()

--- a/postprocessor-cloud-inference-example/postprocessor-cloud-inference-example.py
+++ b/postprocessor-cloud-inference-example/postprocessor-cloud-inference-example.py
@@ -10,7 +10,7 @@ from PIL import Image
 import msgpack
 import struct
 import numpy as np
-from aws_utils import classify_faces
+from aws_utils import classify_faces, create_session
 
 # Add the sclbl-utilities python utilities
 script_location = os.path.dirname(os.path.realpath(__file__))
@@ -149,7 +149,7 @@ def main():
 
             logger.info('Classifying image ' + path)
 
-            description = classify_faces(path, aws_access_key_id, aws_secret_access_key, region_name, logger)
+            description = classify_faces(path, logger)
 
             if description is None:
                 continue
@@ -192,11 +192,21 @@ if __name__ == "__main__":
     logger.info("Initializing cloud interference plugin")
     logger.debug("Input parameters: " + str(sys.argv))
 
-    if (aws_access_key_id == False):
-        logging.error('AWS Key is not set yet', exc_info=True)
-        exit()
-    else:
-        logging.debug('AWS Key: ' + aws_access_key_id)
+    # global rekognition_client
+    #
+    # if rekognition_client is None:
+    #     try:
+    #         rekognition_client = create_session(logger)
+    #     except Exception as e:
+    #         logger.error(e, exc_info=True)
+    #
+    # if rekognition_client is not None:
+    #     logging.debug('AWS Session started')
+    # else:
+    #     logging.error('AWS session failed')
+    #     exit()
+
+    exit(1)
 
     # Parse input arguments
     if len(sys.argv) > 1:

--- a/postprocessor-cloud-inference-example/postprocessor-cloud-inference-example.py
+++ b/postprocessor-cloud-inference-example/postprocessor-cloud-inference-example.py
@@ -152,9 +152,8 @@ def main():
             description = classify_faces(path, logger)
 
             if description is None:
+                logger.info('No description for this face.')
                 continue
-
-            logger.info('Got description ' + description)
 
             # Add the description to the object
             if description not in input_object:
@@ -194,13 +193,12 @@ if __name__ == "__main__":
 
     global rekognition_client
 
-    if rekognition_client is None:
-        try:
-            rekognition_client = create_session(logger)
-        except Exception as e:
-            logger.error(e, exc_info=True)
+    try:
+        rekognition_client = create_session(logger)
+    except Exception as e:
+        logger.error(e, exc_info=True)
 
-    if rekognition_client is not None:
+    if rekognition_client:
         logging.debug('AWS Session started')
     else:
         logging.error('AWS session failed')

--- a/postprocessor-python-edgeimpulse-example/CMakeLists.txt
+++ b/postprocessor-python-edgeimpulse-example/CMakeLists.txt
@@ -3,5 +3,5 @@ add_custom_target(postprocessor-python-edgeimpulse-example ALL
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND pip install -r ../sclbl-utilities/python-utilities/requirements.txt
     COMMAND pip install -r requirements.txt
-    COMMAND pyinstaller postprocessor-python-edgeimpulse-example.py --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
+    COMMAND pyinstaller postprocessor-python-edgeimpulse-example.py --clean --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
 )

--- a/postprocessor-python-edgeimpulse-example/README.md
+++ b/postprocessor-python-edgeimpulse-example/README.md
@@ -151,7 +151,7 @@ Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugin
         {
             "Name":"Example-Postprocessor",
             "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-edgeimpulse-example",
-            "SocketPath":"/tmp/example-postprocessor.sock",
+            "SocketPath":"/tmp/python-edgeimpulse-postprocessor.sock",
             "ReceiveInputTensor": 1,
             "RunLast": false,
             "NoResponse": true

--- a/postprocessor-python-edgeimpulse-example/README.md
+++ b/postprocessor-python-edgeimpulse-example/README.md
@@ -1,7 +1,15 @@
 Edge Impulse Image Uploader
 ===========================
 
-This example application uses a Python based postprocessor to upload images to Edge Impulse for training, either time based, or based on inference confidence.
+This example application uses a Python based postprocessor to upload images to Edge Impulse for training, either interval based with the auto uploader, or based on an inference confidence threshold.
+
+# Requirements
+
+For this example to work, you can use any model.
+
+You also need an Edge Impulse account at https://edgeimpulse.com/.
+
+Edge Impulse usage charges may apply, but it is possible to use the free tier to test this.
 
 # How to use
 
@@ -43,17 +51,17 @@ Before building this postprocessor you need to enter your API key for the Edge I
 
 Replace the key in `api_key` with your own key, you can get your key in Edge Impulse Studio from the "Dashboard > Keys" page. Don't use quotes around the key in the configuration file.
 
-## Use the time based upload
+## Use the interval based upload
 
 When the `auto_generator` is set to `True` images will be uploaded according to the value in `auto_generator_every_seconds`
 
-## Use the confidence based upload
+## Use the confidence threshold based upload
 
 When the `auto_generator` is set to `False` images will be uploaded according to the value in `p_value`
 
 ## Preparation of dependencies
 
-Install needed dependencies
+Install the needed dependencies
 
 ```shell
 sudo apt install cmake
@@ -68,14 +76,14 @@ Change into the directory created for the project if you're not already there.
 cd sclbl-integration-sdk/
 ```
 
-Prepare the *build* directory, while in the project directory.
+Prepare the *build* directory in the project directory, and switch to the build directory.
 
 ```shell
 mkdir -p build
 cd build
 ```
 
-Set up a python virtual environment (needed on recent ubuntu servers) in the newly created build directory
+Set up a python virtual environment in the newly created build directory (on recent ubuntu servers this is required).
 
 ```shell
 python3 -m venv integrationsdk
@@ -84,7 +92,7 @@ source integrationsdk/bin/activate
 
 ## (optionally) Remove other postprocessors for compilation
 
-Edit the `CMakelist.txt` to disable all but the external postprocessor
+Edit the `CMakelist.txt` to disable all but the external postprocessor.
 
 ```shell
 nano ../CMakeLists.txt
@@ -116,27 +124,34 @@ install(PROGRAMS
 
 ## Compile the postprocessor in python
 
-Build and install the postprocessor, while in the created *build* directory.
+Build the postprocessor, while in the created *build* directory. This may take a while, depending on the speed of your system.
 
 ```shell
 cmake ..
 make
-cmake --build . --target install
 ```
 
 ## Install the postprocessor
 
-Once compiled, copy the executable to an accessible directory. 
+Once compiled, copy the executable to an accessible directory.
 
 A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
 
-It's a good idea to make sure the application and settings file you add is readable and executable by the NX AI Edge AI Manager. This can be achieved by running:
+The application and settings files you add must be readable and executable by the NX AI Edge AI Manager. This can be achieved by running:
 
 ```
 sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors
 ```
 
+Install the postprocessor automatically with the cmake command, also from within the *build* directory.
+
+```shell
+cmake --build . --target install
+```
+
 ## Defining the postprocessor
+
+To make the postprocessor available in the NX Server another configuration must be added.
 
 Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/external_postprocessors.json` and add the details of your postprocessor to the root object of that file. For example:
 
@@ -156,6 +171,7 @@ Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugin
 ```
 
 This tells the Edge AI Manager about the postprocessor:
+
 - **Name** gives the postprocesor a name so it can be selected later
 - **Command** defines how to start the postprocessor
 - **SocketPath** tells the AI Manager where to send data to so the external postprocessor will receive it
@@ -175,7 +191,7 @@ sudo service networkoptix-metavms-mediaserver restart
 
 You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
 
-```
+```shell
 sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
 ```
 
@@ -188,7 +204,7 @@ If the postprocessor is defined correctly, its name should appear in the list of
 There is an output log where the uploads can be tracked in real time from the server.
 
 ```shell
-tail -f /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.log
+tail -f /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.edgeimpulse.log
 ```
 
 # Licence

--- a/postprocessor-python-edgeimpulse-example/README.md
+++ b/postprocessor-python-edgeimpulse-example/README.md
@@ -21,42 +21,36 @@ git pull --recurse-submodules
 
 ## Configuration of example postprocessor
 
+Create a new config file `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.edgeimpulse.ini` and add your Edge Impulse API key as well as any overrides of the following settings.
+
+```ini
+[common]
+debug_level=INFO
+[edgeimpulse]
+# Add your own project level Edge Impulse API key
+api_key="ei_add_your_key_here"
+# Option autogenerate images every x seconds as an alternative to sending based on p_value
+auto_generator=True
+# If auto_generator True, every how many seconds upload an image?
+auto_generator_every_seconds=1
+# Flush the buffer at this length
+samples_buffer_flush_size=20
+# Send images below this value to EdgeImpulse. Can be between 0.0 and 1.0
+p_value=0.4
+```
+
 Before building this postprocessor you need to enter your API key for the Edge Impulse Project.
 
-Replace the key in `edge_impulse_api_key` with your own key, you can get your key in Edge Impulse Studio from the "Dashboard > Keys" page
+Replace the key in `api_key` with your own key, you can get your key in Edge Impulse Studio from the "Dashboard > Keys" page
 
-In the python source file find the following line and update the `edge_impulse_api_key`
-
-```python
-# Add your own project level Edge Impulse API key
-edge_impulse_api_key = "ei_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-```
 
 ## Use the time based upload
 
 When the `auto_generator` is set to `True` images will be uploaded according to the value in `auto_generator_every_seconds`
 
-```python
-# Option autogenerate images every x seconds as an alternative to sending based on p_value
-auto_generator = True
-
-# If auto_generator True, every how many seconds upload an image?
-auto_generator_every_seconds = 1
-```
-
 ## Use the confidence based upload
 
 When the `auto_generator` is set to `False` images will be uploaded according to the value in `p_value`
-
-```python
-# Option autogenerate images every x seconds as an alternative to sending based on p_value
-auto_generator = False
-
-# ...
-
-# Send images below this value to EdgeImpulse. Can be between 0.0 and 1.0
-p_value = 0.4
-```
 
 ## Preparation of dependencies
 

--- a/postprocessor-python-edgeimpulse-example/README.md
+++ b/postprocessor-python-edgeimpulse-example/README.md
@@ -28,21 +28,20 @@ Create a new config file `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai
 debug_level=INFO
 [edgeimpulse]
 # Add your own project level Edge Impulse API key
-api_key="ei_add_your_key_here"
+api_key = ei_add_your_key_here
 # Option autogenerate images every x seconds as an alternative to sending based on p_value
-auto_generator=True
+auto_generator = True
 # If auto_generator True, every how many seconds upload an image?
-auto_generator_every_seconds=1
+auto_generator_every_seconds = 1
 # Flush the buffer at this length
-samples_buffer_flush_size=20
+samples_buffer_flush_size = 20
 # Send images below this value to EdgeImpulse. Can be between 0.0 and 1.0
-p_value=0.4
+p_value = 0.4
 ```
 
 Before building this postprocessor you need to enter your API key for the Edge Impulse Project.
 
-Replace the key in `api_key` with your own key, you can get your key in Edge Impulse Studio from the "Dashboard > Keys" page
-
+Replace the key in `api_key` with your own key, you can get your key in Edge Impulse Studio from the "Dashboard > Keys" page. Don't use quotes around the key in the configuration file.
 
 ## Use the time based upload
 
@@ -69,7 +68,7 @@ Change into the directory created for the project if you're not already there.
 cd sclbl-integration-sdk/
 ```
 
-Prepare the build directory, while in the project directory.
+Prepare the *build* directory, while in the project directory.
 
 ```shell
 mkdir -p build
@@ -117,7 +116,7 @@ install(PROGRAMS
 
 ## Compile the postprocessor in python
 
-Build and install the postprocessor, while in the project directory.
+Build and install the postprocessor, while in the created *build* directory.
 
 ```shell
 cmake ..
@@ -127,9 +126,11 @@ cmake --build . --target install
 
 ## Install the postprocessor
 
-Once compiled, copy the executable to an accessible directory. A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
+Once compiled, copy the executable to an accessible directory. 
 
-It's a good idea to make sure the application and settings file you add is readable and executable by the NXAI Edge AI Manager. This can be achieved by running:
+A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
+
+It's a good idea to make sure the application and settings file you add is readable and executable by the NX AI Edge AI Manager. This can be achieved by running:
 
 ```
 sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors
@@ -163,6 +164,20 @@ This tells the Edge AI Manager about the postprocessor:
 - **NoResponse** tells the AI Manager to not wait for a response from this postprocessor
 
 The socket path is always given as the first command line argument when the application is started. It is therefore best practice for the external postprocessor application to read its socket path from here, instead of defining the data twice.
+
+## Restarting the server
+
+Finally, to (re)load your new postprocessor, make sure to restart the NX Server with:
+
+```shell
+sudo service networkoptix-metavms-mediaserver restart
+```
+
+You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
+
+```
+sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+```
 
 ## Selecting to the postprocessor
 

--- a/postprocessor-python-edgeimpulse-example/README.md
+++ b/postprocessor-python-edgeimpulse-example/README.md
@@ -29,7 +29,7 @@ git pull --recurse-submodules
 
 ## Configuration of example postprocessor
 
-Create a new config file `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.edgeimpulse.ini` and add your Edge Impulse API key as well as any overrides of the following settings.
+Create a new [configuration file](plugin.edgeimpulse.ini.example) at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.edgeimpulse.ini` and add your Edge Impulse API key as well as any overrides of the following settings.
 
 ```ini
 [common]

--- a/postprocessor-python-edgeimpulse-example/plugin.edgeimpulse.ini.example
+++ b/postprocessor-python-edgeimpulse-example/plugin.edgeimpulse.ini.example
@@ -1,0 +1,13 @@
+[common]
+debug_level=INFO
+[edgeimpulse]
+# Add your own project level Edge Impulse API key
+api_key = ei_26908c29e9c373b4acc357962a8c0223236274e31d285733f6ec04843ae5ffe4
+# Option autogenerate images every x seconds as an alternative to sending based on p_value
+auto_generator = True
+# If auto_generator True, every how many seconds upload an image?
+auto_generator_every_seconds = 1
+# Flush the buffer at this length
+samples_buffer_flush_size = 20
+# Send images below this value to EdgeImpulse. Can be between 0.0 and 1.0
+p_value = 0.4

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -130,8 +130,8 @@ def config():
         logger.info('new edge_impulse_api_key: ' + edge_impulse_api_key)
 
         auto_generator = config.get('edgeimpulse', 'auto_generator', fallback=False)
-        auto_generator_every_seconds = float(config.get('edgeimpulse', 'auto_generator_every_seconds', fallback=1))
-        samples_buffer_flush_size = float(config.get('edgeimpulse', 'samples_buffer_flush_size', fallback=20))
+        auto_generator_every_seconds = int(config.get('edgeimpulse', 'auto_generator_every_seconds', fallback=1))
+        samples_buffer_flush_size = int(config.get('edgeimpulse', 'samples_buffer_flush_size', fallback=20))
         p_value = float(config.get('edgeimpulse', 'p_value', fallback=0.4))
 
     except Exception as e:

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -18,7 +18,7 @@ import edgeimpulse
 
 # Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
-            "nxai_plugin/nxai_manager/etc/plugin.log")
+            "nxai_plugin/nxai_manager/etc/plugin.edgeimpulse.log")
 
 # Add your own project level Edge Impulse API key   
 edge_impulse_api_key = "ei_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -206,7 +206,7 @@ def main():
                     upload_sample = True
 
         if upload_sample:
-            logging.info("x")
+            # logging.info("EI PLUGIN: uploading sample")
             # Parse image information
             image_header = msgpack.unpackb(image_header)
 
@@ -219,8 +219,8 @@ def main():
                     samples_buffer.append(output.getvalue())
             if len(samples_buffer) >= samples_buffer_flush_size:
                 send_samples_buffer()
-        else:
-            logging.info(".")
+        # else:
+            # logging.info("EI PLUGIN: skipping sample")
         
         if return_data:
              # Create msgpack formatted message

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -18,7 +18,7 @@ import edgeimpulse
 
 # Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
-            "nxai_plugin/nxai_manager/etc/plugin.log")
+            "nxai_plugin/nxai_manager/etc/plugin.edgeimpulse.log")
 
 # Add your own project level Edge Impulse API key   
 edge_impulse_api_key = "ei_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
@@ -46,9 +46,9 @@ p_value = 0.4
 return_data = False
 
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - edge impulse - %(message)s',
                     filename=LOG_FILE, filemode="w")
-logging.debug("EI PLUGIN: Initializing edge impulse plugin")
+logging.debug("Initializing edge impulse plugin")
 
 def send_samples_buffer():
     # This function sends the buffered samples to an Edge Impulse instance for data processing.
@@ -60,12 +60,12 @@ def send_samples_buffer():
     # At the end, it empties the sample buffer.
     global samples_buffer, samples_counter
     if len(samples_buffer) > 0:
-        logging.info("EI PLUGIN: Sending {c} samples to Edge Impulse...".format(c=len(samples_buffer)))
+        logging.info("Sending {c} samples to Edge Impulse...".format(c=len(samples_buffer)))
         start_at = time.perf_counter()
         samples = []
         for contents in samples_buffer:
             samples_counter += 1
-            logging.info("EI PLUGIN: Create sample" + str(samples_counter))
+            logging.info("Create sample" + str(samples_counter))
             filename = "{dt}C{c}.jpg".format(dt=datetime.now().strftime('%Y-%m-%dT%H:%M:%S'), c=samples_counter)
             output = io.BytesIO(contents)
             sample = edgeimpulse.experimental.data.Sample(
@@ -77,23 +77,23 @@ def send_samples_buffer():
             )
             samples.append(sample)
 
-        logging.info("EI PLUGIN: Done creating samples, starting upload...")
+        logging.info("Done creating samples, starting upload...")
         response = edgeimpulse.experimental.data.upload_samples(samples)
-        logging.info("EI PLUGIN: Done upload")
+        logging.info("Done upload")
 
         # Check to make sure there were no failures
         if (len(response.fails)) != 0:
-            logging.info("EI PLUGIN: Could not upload files")
+            logging.info("Could not upload files")
 
         end_at = time.perf_counter()
         logging.info("Send {c} samples in {d:0.1f}sec to Edge Impulse. Total {t}".format(
             c=len(samples_buffer), d=end_at-start_at, t=samples_counter,
         ))
-        logging.info("EI PLUGIN: Send a total of {t} samples to Edge Impulse".format(t=samples_counter))
+        logging.info("Send a total of {t} samples to Edge Impulse".format(t=samples_counter))
 
         samples_buffer = []
     else:
-        logging.info("EI PLUGIN: No samples to send to Edge Impulse. Total {t}".format(t=samples_counter))
+        logging.info("No samples to send to Edge Impulse. Total {t}".format(t=samples_counter))
 
 
 # Add the sclbl-utilities python utilities
@@ -139,7 +139,7 @@ def main():
 
         upload_sample = False
 
-        logging.debug("EI PLUGIN: Wait for message " + str(counter))
+        logging.debug("Wait for message " + str(counter))
         # Wait for input message from runtime
         try:
             input_message, connection = communication_utils.waitForSocketMessage(server)
@@ -150,7 +150,7 @@ def main():
             
         counter = counter + 1
 
-        logging.debug("EI PLUGIN: Message " + str(counter) + " received")
+        logging.debug("Message " + str(counter) + "received")
 
         # Parse input message
         parsed_response = msgpack.unpackb(input_message)
@@ -173,10 +173,10 @@ def main():
                 )
 
         if logging.getLogger().isEnabledFor(logging.DEBUG):
-            logging.debug("EI PLUGIN: Message " + str(counter) + " parsed")
+            logging.debug("Message " + str(counter) + " parsed")
             # Use pformat to format the deep object
             formatted_object = pformat(parsed_response)
-            logging.debug(f'EI PLUGIN: Parsed response:\n\n{formatted_object}\n\n')
+            logging.debug(f'Parsed response:\n\n{formatted_object}\n\n')
 
         current_time = time.time()
 
@@ -184,8 +184,8 @@ def main():
         if auto_generator and current_time - start_time >= auto_generator_every_seconds:
 
             start_time = current_time
-            logging.info("EI PLUGIN: Add timed sample every " + str(auto_generator_every_seconds)
-                         + " seconds, number " + str(counter) + " to upload queue")
+            logging.info("Add timed sample (every )" + str(auto_generator_every_seconds)
+                         + "(seconds) number " + str(counter) + " to upload queue")
             upload_sample = True
 
         elif not auto_generator:
@@ -202,11 +202,11 @@ def main():
             # Check if any of the values are below p_value and earmark result for retrieval
             for value in parsed_values:
                 if value < p_value:
-                    logging.debug("EI PLUGIN: Parsed value: %.8f", value)
+                    logging.debug("Parsed value: %.8f", value)
                     upload_sample = True
 
         if upload_sample:
-            # logging.info("EI PLUGIN: uploading sample")
+            # logging.info("uploading sample")
             # Parse image information
             image_header = msgpack.unpackb(image_header)
 
@@ -220,7 +220,7 @@ def main():
             if len(samples_buffer) >= samples_buffer_flush_size:
                 send_samples_buffer()
         # else:
-            # logging.info("EI PLUGIN: skipping sample")
+            # logging.info("skipping sample")
         
         if return_data:
              # Create msgpack formatted message
@@ -238,14 +238,14 @@ def main():
 
 
 def signalHandler(sig, _):
-    logging.debug("EI PLUGIN: Received interrupt signal: " + str(sig))
+    logging.debug("Received interrupt signal: " + str(sig))
     if len(samples_buffer) > 0:
         send_samples_buffer()
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    logging.debug("EI PLUGIN: Input parameters: " + str(sys.argv))
+    logging.debug("Input parameters: " + str(sys.argv))
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -150,7 +150,7 @@ def main():
             
         counter = counter + 1
 
-        logging.debug("EI PLUGIN: Message " + str(counter) + "received")
+        logging.debug("EI PLUGIN: Message " + str(counter) + " received")
 
         # Parse input message
         parsed_response = msgpack.unpackb(input_message)
@@ -184,8 +184,8 @@ def main():
         if auto_generator and current_time - start_time >= auto_generator_every_seconds:
 
             start_time = current_time
-            logging.info("EI PLUGIN: Add timed sample (every )" + str(auto_generator_every_seconds)
-                         + "(seconds) number " + str(counter) + " to upload queue")
+            logging.info("EI PLUGIN: Add timed sample every " + str(auto_generator_every_seconds)
+                         + " seconds, number " + str(counter) + " to upload queue")
             upload_sample = True
 
         elif not auto_generator:

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -18,7 +18,6 @@ import edgeimpulse
 CONFIG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
                "nxai_plugin/nxai_manager/etc/plugin.edgeimpulse.ini")
 
-# Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
             "nxai_plugin/nxai_manager/etc/plugin.edgeimpulse.log")
 
@@ -112,27 +111,26 @@ def config():
     logger.info('Reading configuration from:' + CONFIG_FILE)
 
     try:
-        config = configparser.ConfigParser()
-        config.read(CONFIG_FILE)
+        configuration = configparser.ConfigParser()
+        configuration.read(CONFIG_FILE)
 
-        configured_log_level = config.get('common', 'debug_level', fallback = 'INFO')
+        configured_log_level = configuration.get('common', 'debug_level', fallback = 'INFO')
         setLogLevel(configured_log_level)
 
-        for section in config.sections():
+        for section in configuration.sections():
             logger.info('config section: ' + section)
-            for key in config[section]:
-                logger.info('config key: ' + key + ' = ' + config[section][key])
+            for key in configuration[section]:
+                logger.info('config key: ' + key + ' = ' + configuration[section][key])
 
         # Override default values from config
-        edge_impulse_api_key = config.get('edgeimpulse', 'api_key', fallback=default_edge_impulse_api_key)
+        edge_impulse_api_key = configuration.get('edgeimpulse', 'api_key', fallback=default_edge_impulse_api_key)
 
-        logger.info('default edge_impulse_api_key: ' + default_edge_impulse_api_key)
         logger.info('new edge_impulse_api_key: ' + edge_impulse_api_key)
 
-        auto_generator = config.get('edgeimpulse', 'auto_generator', fallback=False)
-        auto_generator_every_seconds = int(config.get('edgeimpulse', 'auto_generator_every_seconds', fallback=1))
-        samples_buffer_flush_size = int(config.get('edgeimpulse', 'samples_buffer_flush_size', fallback=20))
-        p_value = float(config.get('edgeimpulse', 'p_value', fallback=0.4))
+        auto_generator = configuration.get('edgeimpulse', 'auto_generator', fallback=False)
+        auto_generator_every_seconds = int(configuration.get('edgeimpulse', 'auto_generator_every_seconds', fallback=1))
+        samples_buffer_flush_size = int(configuration.get('edgeimpulse', 'samples_buffer_flush_size', fallback=20))
+        p_value = float(configuration.get('edgeimpulse', 'p_value', fallback=0.4))
 
     except Exception as e:
         logger.error(e, exc_info=True)
@@ -145,6 +143,7 @@ def setLogLevel(level):
         logger.setLevel(level)
     except Exception as e:
         logger.error(e, exc_info=True)
+
 
 def main():
 
@@ -290,15 +289,16 @@ if __name__ == "__main__":
 
     if (edge_impulse_api_key == default_edge_impulse_api_key):
         logging.error('Edge Impulse Key is not set yet', exc_info=True)
-        exit
+        exit()
     else:
-        logging.error('Edge Impulse Key: ' + edge_impulse_api_key)
+        logging.debug('Edge Impulse Key: ' + edge_impulse_api_key)
 
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]
     # Handle interrupt signals
     signal.signal(signal.SIGINT, signalHandler)
+
     # Start program
     try:
         main()

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -245,7 +245,7 @@ def signalHandler(sig, _):
 
 
 if __name__ == "__main__":
-    logging.info("Input parameters: " + str(sys.argv))
+    logging.debug("Input parameters: " + str(sys.argv))
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -18,7 +18,7 @@ import edgeimpulse
 
 # Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
-            "nxai_plugin/nxai_manager/etc/plugin.edgeimpulse.log")
+            "nxai_plugin/nxai_manager/etc/plugin.log")
 
 # Add your own project level Edge Impulse API key   
 edge_impulse_api_key = "ei_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -48,7 +48,7 @@ return_data = False
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - edge impulse - %(message)s',
                     filename=LOG_FILE, filemode="w")
-logging.debug("Initializing edge impulse plugin")
+logging.info("Initializing edge impulse plugin")
 
 def send_samples_buffer():
     # This function sends the buffered samples to an Edge Impulse instance for data processing.
@@ -132,7 +132,7 @@ def main():
 
     # Get the current time at the start
     start_time = time.time()
-    
+
     # Wait for messages in a loop
     counter = 0
     while True:
@@ -147,7 +147,7 @@ def main():
         except socket.timeout:
             # Request timed out. Continue waiting
             continue
-            
+
         counter = counter + 1
 
         logging.debug("Message " + str(counter) + "received")
@@ -184,8 +184,8 @@ def main():
         if auto_generator and current_time - start_time >= auto_generator_every_seconds:
 
             start_time = current_time
-            logging.info("Add timed sample (every )" + str(auto_generator_every_seconds)
-                         + "(seconds) number " + str(counter) + " to upload queue")
+            logging.info("Add timed sample every " + str(auto_generator_every_seconds)
+                         + " seconds number " + str(counter) + " to upload queue")
             upload_sample = True
 
         elif not auto_generator:
@@ -206,7 +206,7 @@ def main():
                     upload_sample = True
 
         if upload_sample:
-            # logging.info("uploading sample")
+            logging.debug("uploading sample")
             # Parse image information
             image_header = msgpack.unpackb(image_header)
 
@@ -219,9 +219,9 @@ def main():
                     samples_buffer.append(output.getvalue())
             if len(samples_buffer) >= samples_buffer_flush_size:
                 send_samples_buffer()
-        # else:
-            # logging.info("skipping sample")
-        
+        else:
+            logging.debug("skipping sample")
+
         if return_data:
              # Create msgpack formatted message
             data_types = parsed_response.get("OutputDataTypes")
@@ -238,14 +238,14 @@ def main():
 
 
 def signalHandler(sig, _):
-    logging.debug("Received interrupt signal: " + str(sig))
+    logging.info("Received interrupt signal: " + str(sig))
     if len(samples_buffer) > 0:
         send_samples_buffer()
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    logging.debug("Input parameters: " + str(sys.argv))
+    logging.info("Input parameters: " + str(sys.argv))
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -103,7 +103,7 @@ import communication_utils
 
 # The name of the postprocessor.
 # This is used to match the definition of the postprocessor with routing.
-Postprocessor_Name = "Python-Example-Postprocessor"
+Postprocessor_Name = "Python-EdgeImpulse-Postprocessor"
 
 # The socket this postprocessor will listen on.
 # This is always given as the first argument when the process is started

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -108,7 +108,7 @@ Postprocessor_Name = "Python-EdgeImpulse-Postprocessor"
 # The socket this postprocessor will listen on.
 # This is always given as the first argument when the process is started
 # But it can be manually defined as well, as long as it is the same as the socket path in the runtime settings
-Postprocessor_Socket_Path = "/tmp/python-example-postprocessor.sock"
+Postprocessor_Socket_Path = "/tmp/python-edgeimpulse-postprocessor.sock"
 
 
 def main():

--- a/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
+++ b/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example.py
@@ -48,7 +48,7 @@ return_data = False
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',
                     filename=LOG_FILE, filemode="w")
-logging.debug("Initializing plugin")
+logging.debug("EI PLUGIN: Initializing edge impulse plugin")
 
 def send_samples_buffer():
     # This function sends the buffered samples to an Edge Impulse instance for data processing.
@@ -60,12 +60,12 @@ def send_samples_buffer():
     # At the end, it empties the sample buffer.
     global samples_buffer, samples_counter
     if len(samples_buffer) > 0:
-        logging.info("Sending {c} samples to Edge Impulse...".format(c=len(samples_buffer)))
+        logging.info("EI PLUGIN: Sending {c} samples to Edge Impulse...".format(c=len(samples_buffer)))
         start_at = time.perf_counter()
         samples = []
         for contents in samples_buffer:
             samples_counter += 1
-            logging.info("Create sample" + str(samples_counter))
+            logging.info("EI PLUGIN: Create sample" + str(samples_counter))
             filename = "{dt}C{c}.jpg".format(dt=datetime.now().strftime('%Y-%m-%dT%H:%M:%S'), c=samples_counter)
             output = io.BytesIO(contents)
             sample = edgeimpulse.experimental.data.Sample(
@@ -77,23 +77,23 @@ def send_samples_buffer():
             )
             samples.append(sample)
 
-        logging.info("Done creating samples, starting upload...")
+        logging.info("EI PLUGIN: Done creating samples, starting upload...")
         response = edgeimpulse.experimental.data.upload_samples(samples)
-        logging.info("Done upload")
+        logging.info("EI PLUGIN: Done upload")
 
         # Check to make sure there were no failures
         if (len(response.fails)) != 0:
-            logging.info("Could not upload files")
+            logging.info("EI PLUGIN: Could not upload files")
 
         end_at = time.perf_counter()
         logging.info("Send {c} samples in {d:0.1f}sec to Edge Impulse. Total {t}".format(
             c=len(samples_buffer), d=end_at-start_at, t=samples_counter,
         ))
-        logging.info("Send a total of {t} samples to Edge Impulse".format(t=samples_counter))
+        logging.info("EI PLUGIN: Send a total of {t} samples to Edge Impulse".format(t=samples_counter))
 
         samples_buffer = []
     else:
-        logging.info("No samples to send to Edge Impulse. Total {t}".format(t=samples_counter))
+        logging.info("EI PLUGIN: No samples to send to Edge Impulse. Total {t}".format(t=samples_counter))
 
 
 # Add the sclbl-utilities python utilities
@@ -139,7 +139,7 @@ def main():
 
         upload_sample = False
 
-        logging.debug("Wait for message " + str(counter))
+        logging.debug("EI PLUGIN: Wait for message " + str(counter))
         # Wait for input message from runtime
         try:
             input_message, connection = communication_utils.waitForSocketMessage(server)
@@ -150,7 +150,7 @@ def main():
             
         counter = counter + 1
 
-        logging.debug("Message " + str(counter) + "received")
+        logging.debug("EI PLUGIN: Message " + str(counter) + "received")
 
         # Parse input message
         parsed_response = msgpack.unpackb(input_message)
@@ -173,10 +173,10 @@ def main():
                 )
 
         if logging.getLogger().isEnabledFor(logging.DEBUG):
-            logging.debug("Message " + str(counter) + " parsed")
+            logging.debug("EI PLUGIN: Message " + str(counter) + " parsed")
             # Use pformat to format the deep object
             formatted_object = pformat(parsed_response)
-            logging.debug(f'Parsed response:\n\n{formatted_object}\n\n')
+            logging.debug(f'EI PLUGIN: Parsed response:\n\n{formatted_object}\n\n')
 
         current_time = time.time()
 
@@ -184,7 +184,7 @@ def main():
         if auto_generator and current_time - start_time >= auto_generator_every_seconds:
 
             start_time = current_time
-            logging.info("Add timed sample (every )" + str(auto_generator_every_seconds)
+            logging.info("EI PLUGIN: Add timed sample (every )" + str(auto_generator_every_seconds)
                          + "(seconds) number " + str(counter) + " to upload queue")
             upload_sample = True
 
@@ -202,7 +202,7 @@ def main():
             # Check if any of the values are below p_value and earmark result for retrieval
             for value in parsed_values:
                 if value < p_value:
-                    logging.debug("Parsed value: %.8f", value)
+                    logging.debug("EI PLUGIN: Parsed value: %.8f", value)
                     upload_sample = True
 
         if upload_sample:
@@ -238,14 +238,14 @@ def main():
 
 
 def signalHandler(sig, _):
-    logging.debug("EXAMPLE PLUGIN: Received interrupt signal: " + str(sig))
+    logging.debug("EI PLUGIN: Received interrupt signal: " + str(sig))
     if len(samples_buffer) > 0:
         send_samples_buffer()
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    logging.debug("EXAMPLE PLUGIN: Input parameters: " + str(sys.argv))
+    logging.debug("EI PLUGIN: Input parameters: " + str(sys.argv))
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]

--- a/postprocessor-python-example/CMakeLists.txt
+++ b/postprocessor-python-example/CMakeLists.txt
@@ -3,5 +3,5 @@ add_custom_target(postprocessor-python-example ALL
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND pip install -r ../sclbl-utilities/python-utilities/requirements.txt
     COMMAND pip install -r requirements.txt
-    COMMAND pyinstaller postprocessor-python-example.py --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
+    COMMAND pyinstaller postprocessor-python-example.py --clean --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
 )

--- a/postprocessor-python-example/README.md
+++ b/postprocessor-python-example/README.md
@@ -3,6 +3,8 @@ Postprocessor Python Example
 
 This example application provides an example on how to create a Python based postprocessor that can be integrated with the NXAI Edge AI Manager.
 
+This plugin adds a 100 x 100 bounding box at 100 from the top and 100 from the left of the camera stream with the label "test".
+
 # Postprocessors Control Flow
 
 The normal control flow of a postprocessor is to receive a MessagePack binary message representing the inference results from the NXAI Edge AI Manager, and return the same or an altered version of the received MessagePack message.

--- a/postprocessor-python-example/README.md
+++ b/postprocessor-python-example/README.md
@@ -19,7 +19,7 @@ The incoming MessagePack message follows a specific schema. If the message is al
 {
     "Timestamp": <Timestamp>,
     "Width": <Width>,
-    "Height": <Hieght>,
+    "Height": <Height>,
     "InputIndex": <Index>,
     "Counts": {
         <"Class Name">: <Class Count>

--- a/postprocessor-python-example/README.md
+++ b/postprocessor-python-example/README.md
@@ -87,6 +87,20 @@ This tells the Edge AI Manager about the postprocessor:
 
 The socket path is always given as the first command line argument when the application is started. It is therefore best practice for the external postprocessor application to read its socket path from here, instead of defining the data twice.
 
+## Restarting the server
+
+Finally, to (re)load your new postprocessor, make sure to restart the NX Server with:
+
+```shell
+sudo service networkoptix-metavms-mediaserver restart
+```
+
+You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
+
+```
+sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+```
+
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.

--- a/postprocessor-python-example/README.md
+++ b/postprocessor-python-example/README.md
@@ -72,7 +72,7 @@ git pull --recurse-submodules
 
 ## Configuration of example postprocessor
 
-Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.example.ini` and add some overrides for the configuration.
+Create a [configuration file](plugin.example.ini.example) at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.example.ini` and add some overrides for the configuration.
 
 This plugin only supports changing the debug level between DEBUG, INFO, WARNING, ERROR and CRITICAL
 

--- a/postprocessor-python-example/README.md
+++ b/postprocessor-python-example/README.md
@@ -47,9 +47,24 @@ It's a good idea to make sure the application and settings file you add is reada
 sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors
 ```
 
+## Local configuration
+
+Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.example.ini` and add some overrides for the configuration. 
+
+This plugin only supports changing the debug level between DEBUG, INFO, WARNING, ERROR and CRITICAL
+
+For example:
+
+```ini
+[common]
+debug_level=DEBUG
+```
+
 ## Defining the postprocessor
 
-Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/external_postprocessors.json` and add the details of your postprocessor to the root object of that file. For example: 
+Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/external_postprocessors.json` and add the details of your postprocessor to the root object of that file. 
+
+For example: 
 
 ``` json
 {

--- a/postprocessor-python-example/README.md
+++ b/postprocessor-python-example/README.md
@@ -55,7 +55,7 @@ Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugin
         {
             "Name":"Example-Postprocessor",
             "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-example",
-            "SocketPath":"/tmp/example-postprocessor.sock",
+            "SocketPath":"/tmp/python-example-postprocessor.sock",
             "ReceiveInputTensor": 0
         }
     ]
@@ -73,7 +73,6 @@ The socket path is always given as the first command line argument when the appl
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
-
 
 # Licence
 

--- a/postprocessor-python-example/README.md
+++ b/postprocessor-python-example/README.md
@@ -1,5 +1,5 @@
 Postprocessor Python Example
-=========================
+============================
 
 This example application provides an example on how to create a Python based postprocessor that can be integrated with the NXAI Edge AI Manager.
 
@@ -19,37 +19,60 @@ The incoming MessagePack message follows a specific schema. If the message is al
 
 ```json
 {
-    "Timestamp": <Timestamp>,
-    "Width": <Width>,
-    "Height": <Height>,
-    "InputIndex": <Index>,
-    "Counts": {
-        <"Class Name">: <Class Count>
-    },
-    "BBoxes_xyxy": {
-        <"Class Name">: [
-            <Coordinates>
-        ]
-    },
-    "Scores": {
-        <"Class Name"> : <Score>
-    }
+  "Timestamp": <Timestamp>,
+  "Width": <Width>,
+  "Height": <Height>,
+  "InputIndex": <Index>,
+  "Counts": {
+    <"Class Name">: <Class Count>
+  },
+  "BBoxes_xyxy": {
+    <"Class Name">: [
+      <Coordinates>
+    ]
+  },
+  "Scores": {
+    <"Class Name"> : <Score>
+  }
 }
 ```
 
+The image header message contains fields indicating information about the image dimensions and information to access this data:
+
+```json
+{
+    "Width": <Width>,
+    "Height": <Height>,
+    "SHMKey": <SHM Key>,
+    "SHMID": <SHM ID>
+}
+```
+
+A convenience example function is provided showing how to use this data to access the original tensor data in shared memory.
+
+# Requirements
+
+For this example to work, you can use any model.
+
 # How to use
 
-Once compiled, copy the executable to an accessible directory. A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
+## Download the integration SDK
 
-It's a good idea to make sure the application and settings file you add is readable and executable by the NXAI Edge AI Manager. This can be achieved by running:
+You probably have the integration SDK already if you're looking at this readme, the command to get the full integration SDK is as follows:
 
+```shell
+git clone https://github.com/scailable/sclbl-integration-sdk.git --recurse-submodules
 ```
-sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors
+
+If you have downloaded the sdk previously, you can also update to the latest version of the integration SDK while in the directory of the downloaded git repository.
+
+```shell
+git pull --recurse-submodules
 ```
 
-## Local configuration
+## Configuration of example postprocessor
 
-Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.example.ini` and add some overrides for the configuration. 
+Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.example.ini` and add some overrides for the configuration.
 
 This plugin only supports changing the debug level between DEBUG, INFO, WARNING, ERROR and CRITICAL
 
@@ -60,11 +83,109 @@ For example:
 debug_level=DEBUG
 ```
 
+## Use the interval based upload
+
+When the `auto_generator` is set to `True` images will be uploaded according to the value in `auto_generator_every_seconds`
+
+## Use the confidence threshold based upload
+
+When the `auto_generator` is set to `False` images will be uploaded according to the value in `p_value`
+
+## Preparation of dependencies
+
+Install the needed dependencies
+
+```shell
+sudo apt install cmake
+sudo apt install g++
+sudo apt install python3-pip
+sudo apt install python3.12-venv
+```
+
+Change into the directory created for the project if you're not already there.
+
+```shell
+cd sclbl-integration-sdk/
+```
+
+Prepare the *build* directory in the project directory, and switch to the build directory.
+
+```shell
+mkdir -p build
+cd build
+```
+
+Set up a python virtual environment in the newly created build directory (on recent ubuntu servers this is required).
+
+```shell
+python3 -m venv integrationsdk
+source integrationsdk/bin/activate
+```
+
+## (optionally) Remove other postprocessors for compilation
+
+Edit the `CMakelist.txt` to disable all but the external postprocessor.
+
+```shell
+nano ../CMakeLists.txt
+```
+
+It should look similar to this
+
+```shell
+cmake_minimum_required(VERSION 3.10.2)
+
+project(sclbl-integration-examples)
+
+# Add Scailable C Utilities for all subprojects
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sclbl-utilities)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/sclbl-utilities/include)
+
+# Add Edge Impulse Postprocessor Python project
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/postprocessor-python-edgeimpulse-example)
+
+# Add installation option
+install(TARGETS
+    DESTINATION /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+)
+install(PROGRAMS
+    ${CMAKE_CURRENT_BINARY_DIR}/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example
+    DESTINATION /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+)
+```
+
+## Compile the postprocessor in python
+
+Build the postprocessor, while in the created *build* directory. This may take a while, depending on the speed of your system.
+
+```shell
+cmake ..
+make
+```
+
+## Install the postprocessor
+
+Once compiled, copy the executable to an accessible directory.
+
+A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
+
+The application and settings files you add must be readable and executable by the NX AI Edge AI Manager. This can be achieved by running:
+
+```
+sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors
+```
+
+Install the postprocessor automatically with the cmake command, also from within the *build* directory.
+
+```shell
+cmake --build . --target install
+```
+
 ## Defining the postprocessor
 
-Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/external_postprocessors.json` and add the details of your postprocessor to the root object of that file. 
+Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/external_postprocessors.json` and add the details of your postprocessor to the root object of that file.
 
-For example: 
+For example:
 
 ``` json
 {
@@ -97,13 +218,21 @@ sudo service networkoptix-metavms-mediaserver restart
 
 You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
 
-```
+```shell
 sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
 ```
 
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
+
+## Output logging
+
+There is an output log where the uploads can be tracked in real time from the server.
+
+```shell
+tail -f /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.example.log
+```
 
 # Licence
 

--- a/postprocessor-python-example/plugin.example.ini.example
+++ b/postprocessor-python-example/plugin.example.ini.example
@@ -1,0 +1,2 @@
+[common]
+debug_level=INFO

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -2,8 +2,14 @@ import os
 import sys
 import socket
 import signal
-from pprint import pformat
 import logging
+import io
+import time
+from pprint import pformat
+import msgpack
+import struct
+from math import prod
+from datetime import datetime
 
 # Add the sclbl-utilities python utilities
 script_location = os.path.dirname(os.path.realpath(__file__))

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -12,7 +12,7 @@ import communication_utils
 
 # Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
-            "nxai_plugin/nxai_manager/etc/plugin.log")
+            "nxai_plugin/nxai_manager/etc/plugin.example.log")
 
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -3,13 +3,7 @@ import sys
 import socket
 import signal
 import logging
-import io
-import time
 from pprint import pformat
-import msgpack
-import struct
-from math import prod
-from datetime import datetime
 
 # Add the sclbl-utilities python utilities
 script_location = os.path.dirname(os.path.realpath(__file__))
@@ -52,6 +46,9 @@ Postprocessor_Socket_Path = "/tmp/python-example-postprocessor.sock"
 def main():
     # Start socket listener to receive messages from NXAI runtime
     server = communication_utils.startUnixSocketServer(Postprocessor_Socket_Path)
+
+    logging.debug("EXAMPLE PLUGIN: Start socket listener: " + Postprocessor_Socket_Path)
+
     # Wait for messages in a loop
     while True:
         # Wait for input message from runtime
@@ -59,6 +56,7 @@ def main():
             input_message, connection = communication_utils.waitForSocketMessage(server)
         except socket.timeout:
             # Request timed out. Continue waiting
+            logging.debug("EXAMPLE PLUGIN: Request timed out. Continue waiting")
             continue
 
         logging.debug("EXAMPLE PLUGIN: Received input message: " + input_message)

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -2,6 +2,7 @@ import os
 import sys
 import socket
 import signal
+from pprint import pformat
 import logging
 
 # Add the sclbl-utilities python utilities
@@ -54,19 +55,21 @@ def main():
             # Request timed out. Continue waiting
             continue
 
-        logging.debug("EXAMPLE PLUGIN: Received input message: ", input_message)
+        logging.debug("EXAMPLE PLUGIN: Received input message: " + input_message)
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
 
-        logging.debug("Unpacked ", input_object)
+        formatted_unpacked_object = pformat(input_object)
+        logging.debug(f'EXAMPLE PLUGIN: Unpacked:\n\n{formatted_unpacked_object}\n\n')
 
         # Add extra bbox
         if "BBoxes_xyxy" not in input_object:
             input_object["BBoxes_xyxy"] = {}
         input_object["BBoxes_xyxy"]["test"] = [100.0, 100.0, 200.0, 200.0]
 
-        logging.debug("Packing ", input_object)
+        formatted_packed_object = pformat(input_object)
+        logging.debug(f'EXAMPLE PLUGIN: Packing:\n\n{formatted_packed_object}\n\n')
 
         # Write object back to string
         output_message = communication_utils.writeInferenceResults(input_object)
@@ -76,12 +79,12 @@ def main():
 
 
 def signalHandler(sig, _):
-    logging.debug("EXAMPLE PLUGIN: Received interrupt signal: ", sig)
+    logging.debug("EXAMPLE PLUGIN: Received interrupt signal: " + str(sig))
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    logging.debug("EXAMPLE PLUGIN: Input parameters: ", sys.argv)
+    logging.debug("EXAMPLE PLUGIN: Input parameters: " + str(sys.argv))
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -84,11 +84,11 @@ def main():
 
         try:
             input_message, connection = communication_utils.waitForSocketMessage(server)
+            logger.debug("Received input message")
         except socket.timeout:
             # Request timed out. Continue waiting
             continue
 
-        logger.debug("Received input message")
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -3,7 +3,6 @@ import sys
 import socket
 import signal
 import logging
-# from pprint import pformat
 
 # Add the sclbl-utilities python utilities
 script_location = os.path.dirname(os.path.realpath(__file__))
@@ -46,7 +45,6 @@ Postprocessor_Socket_Path = "/tmp/python-example-postprocessor.sock"
 def main():
     # Start socket listener to receive messages from NXAI runtime
     server = communication_utils.startUnixSocketServer(Postprocessor_Socket_Path)
-    logging.info("startUnixSocketServer", + str(Postprocessor_Socket_Path))
 
     # Wait for messages in a loop
     while True:
@@ -73,9 +71,7 @@ def main():
             input_object["BBoxes_xyxy"] = {}
         input_object["BBoxes_xyxy"]["test"] = [100.0, 100.0, 200.0, 200.0]
 
-        # Use pformat to format the deep object
-        # formatted_packed_object = pformat(input_object)
-        # logging.debug(f'Packing:\n\n{formatted_packed_object}\n\n')
+        logging.info("Added test bounding box to output")
 
         # Write object back to string
         output_message = communication_utils.writeInferenceResults(input_object)

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -49,16 +49,16 @@ def config():
     logger.info('Reading configuration from:' + CONFIG_FILE)
 
     try:
-        config = configparser.ConfigParser()
-        config.read(CONFIG_FILE)
+        configuration = configparser.ConfigParser()
+        configuration.read(CONFIG_FILE)
 
-        configured_log_level = config.get('common', 'debug_level', fallback = 'INFO')
+        configured_log_level = configuration.get('common', 'debug_level', fallback = 'INFO')
         setLogLevel(configured_log_level)
 
-        for section in config.sections():
+        for section in configuration.sections():
             logger.info('config section: ' + section)
-            for key in config[section]:
-                logger.info('config key: ' + key + ' = ' + config[section][key])
+            for key in configuration[section]:
+                logger.info('config key: ' + key + ' = ' + configuration[section][key])
 
     except Exception as e:
         logger.error(e, exc_info=True)

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -17,7 +17,7 @@ LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - example - %(message)s',
                     filename=LOG_FILE, filemode="w")
-logging.debug("Initializing example plugin")
+logging.info("Initializing example plugin")
 
 # The name of the postprocessor.
 # This is used to match the definition of the postprocessor with routing.
@@ -46,6 +46,7 @@ Postprocessor_Socket_Path = "/tmp/python-example-postprocessor.sock"
 def main():
     # Start socket listener to receive messages from NXAI runtime
     server = communication_utils.startUnixSocketServer(Postprocessor_Socket_Path)
+    logging.info("startUnixSocketServer", + str(Postprocessor_Socket_Path))
 
     # Wait for messages in a loop
     while True:
@@ -56,7 +57,6 @@ def main():
             input_message, connection = communication_utils.waitForSocketMessage(server)
         except socket.timeout:
             # Request timed out. Continue waiting
-            logging.debug("Socket timed out")
             continue
 
         logging.debug("Received input message")
@@ -85,7 +85,7 @@ def main():
 
 
 def signalHandler(sig, _):
-    logging.debug("Received interrupt signal: " + str(sig))
+    logging.info("Received interrupt signal: " + str(sig))
     sys.exit(0)
 
 

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -53,7 +53,7 @@ def config():
         configuration.read(CONFIG_FILE)
 
         configured_log_level = configuration.get('common', 'debug_level', fallback = 'INFO')
-        setLogLevel(configured_log_level)
+        set_log_level(configured_log_level)
 
         for section in configuration.sections():
             logger.info('config section: ' + section)
@@ -66,11 +66,16 @@ def config():
     logger.debug('Read configuration done')
 
 
-def setLogLevel(level):
+def set_log_level(level):
     try:
         logger.setLevel(level)
     except Exception as e:
         logger.error(e, exc_info=True)
+
+
+def signal_handler(sig, _):
+    logger.info("Received interrupt signal: " + str(sig))
+    sys.exit(0)
 
 
 def main():
@@ -88,7 +93,6 @@ def main():
         except socket.timeout:
             # Request timed out. Continue waiting
             continue
-
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
@@ -111,11 +115,6 @@ def main():
         communication_utils.sendMessageOverConnection(connection, output_message)
 
 
-def signalHandler(sig, _):
-    logger.info("Received interrupt signal: " + str(sig))
-    sys.exit(0)
-
-
 if __name__ == "__main__":
     ## initialize the logger
     logger = logging.getLogger(__name__)
@@ -130,7 +129,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]
     # Handle interrupt signals
-    signal.signal(signal.SIGINT, signalHandler)
+    signal.signal(signal.SIGINT, signal_handler)
     # Start program
     try:
         main()

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -2,11 +2,21 @@ import os
 import sys
 import socket
 import signal
+import logging
 
 # Add the sclbl-utilities python utilities
 script_location = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(script_location, "../sclbl-utilities/python-utilities"))
 import communication_utils
+
+# Set up logging
+LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
+            "nxai_plugin/nxai_manager/etc/plugin.log")
+
+# Initialize plugin and logging, script makes use of INFO and DEBUG levels
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',
+                    filename=LOG_FILE, filemode="w")
+logging.debug("EXAMPLE PLUGIN: Initializing plugin")
 
 # The name of the postprocessor.
 # This is used to match the definition of the postprocessor with routing.
@@ -44,19 +54,19 @@ def main():
             # Request timed out. Continue waiting
             continue
 
-        print("EXAMPLE PLUGIN: Received input message: ", input_message)
+        logging.debug("EXAMPLE PLUGIN: Received input message: ", input_message)
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
 
-        print("Unpacked ", input_object)
+        logging.debug("Unpacked ", input_object)
 
         # Add extra bbox
         if "BBoxes_xyxy" not in input_object:
             input_object["BBoxes_xyxy"] = {}
         input_object["BBoxes_xyxy"]["test"] = [100.0, 100.0, 200.0, 200.0]
 
-        print("Packing ", input_object)
+        logging.debug("Packing ", input_object)
 
         # Write object back to string
         output_message = communication_utils.writeInferenceResults(input_object)
@@ -66,12 +76,12 @@ def main():
 
 
 def signalHandler(sig, _):
-    print("EXAMPLE PLUGIN: Received interrupt signal: ", sig)
+    logging.debug("EXAMPLE PLUGIN: Received interrupt signal: ", sig)
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    print("EXAMPLE PLUGIN: Input parameters: ", sys.argv)
+    logging.debug("EXAMPLE PLUGIN: Input parameters: ", sys.argv)
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]

--- a/postprocessor-python-example/postprocessor-python-example.py
+++ b/postprocessor-python-example/postprocessor-python-example.py
@@ -12,7 +12,7 @@ import communication_utils
 
 # Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
-            "nxai_plugin/nxai_manager/etc/plugin.example.log")
+            "nxai_plugin/nxai_manager/etc/plugin.log")
 
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',

--- a/postprocessor-python-image-example/CMakeLists.txt
+++ b/postprocessor-python-image-example/CMakeLists.txt
@@ -3,5 +3,5 @@ add_custom_target(postprocessor-python-image-example ALL
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND pip install -r ../sclbl-utilities/python-utilities/requirements.txt
     COMMAND pip install -r requirements.txt
-    COMMAND pyinstaller postprocessor-python-image-example.py --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
+    COMMAND pyinstaller postprocessor-python-image-example.py --clean --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
 )

--- a/postprocessor-python-image-example/README.md
+++ b/postprocessor-python-image-example/README.md
@@ -72,7 +72,7 @@ git pull --recurse-submodules
 
 ## Configuration of example postprocessor
 
-Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.image.ini` and add some overrides for the configuration.
+Create a [configuration file](plugin.image.ini.example) at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.image.ini` and add some overrides for the configuration.
 
 This plugin only supports changing the debug level between DEBUG, INFO, WARNING, ERROR and CRITICAL
 

--- a/postprocessor-python-image-example/README.md
+++ b/postprocessor-python-image-example/README.md
@@ -21,7 +21,7 @@ The incoming MessagePack message follows a specific schema. If the message is al
 {
     "Timestamp": <Timestamp>,
     "Width": <Width>,
-    "Height": <Hieght>,
+    "Height": <Height>,
     "InputIndex": <Index>,
     "Counts": {
         <"Class Name">: <Class Count>
@@ -42,7 +42,6 @@ The image header message contains fields indicating information about the image 
 ```json
 {
     "Width": <Width>,
-    "Height": <Height>,
     "Height": <Height>,
     "SHMKey": <SHM Key>,
     "SHMID": <SHM ID>

--- a/postprocessor-python-image-example/README.md
+++ b/postprocessor-python-image-example/README.md
@@ -85,6 +85,20 @@ This tells the Edge AI Manager about the postprocessor:
 
 The socket path is always given as the first command line argument when the application is started. It is therefore best practice for the external postprocessor application to read its socket path from here, instead of defining the data twice.
 
+## Restarting the server
+
+Finally, to (re)load your new postprocessor, make sure to restart the NX Server with:
+
+```shell
+sudo service networkoptix-metavms-mediaserver restart
+```
+
+You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
+
+```
+sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+```
+
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.

--- a/postprocessor-python-image-example/README.md
+++ b/postprocessor-python-image-example/README.md
@@ -70,7 +70,7 @@ Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugin
         {
             "Name":"Example-Postprocessor",
             "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-image-example",
-            "SocketPath":"/tmp/example-postprocessor.sock",
+            "SocketPath":"/tmp/python-image-postprocessor.sock",
             "ReceiveInputTensor": 1
         }
     ]
@@ -88,7 +88,6 @@ The socket path is always given as the first command line argument when the appl
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
-
 
 # Licence
 

--- a/postprocessor-python-image-example/README.md
+++ b/postprocessor-python-image-example/README.md
@@ -50,19 +50,140 @@ The image header message contains fields indicating information about the image 
 
 A convenience example function is provided showing how to use this data to access the original tensor data in shared memory.
 
+# Requirements
+
+For this example to work, you can use any model.
+
 # How to use
 
-Once compiled, copy the executable to an accessible directory. A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
+## Download the integration SDK
 
-It's a good idea to make sure the application and settings file you add is readable and executable by the NXAI Edge AI Manager. This can be achieved by running:
+You probably have the integration SDK already if you're looking at this readme, the command to get the full integration SDK is as follows:
+
+```shell
+git clone https://github.com/scailable/sclbl-integration-sdk.git --recurse-submodules
+```
+
+If you have downloaded the sdk previously, you can also update to the latest version of the integration SDK while in the directory of the downloaded git repository.
+
+```shell
+git pull --recurse-submodules
+```
+
+## Configuration of example postprocessor
+
+Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.image.ini` and add some overrides for the configuration.
+
+This plugin only supports changing the debug level between DEBUG, INFO, WARNING, ERROR and CRITICAL
+
+For example:
+
+```ini
+[common]
+debug_level=DEBUG
+```
+
+## Use the interval based upload
+
+When the `auto_generator` is set to `True` images will be uploaded according to the value in `auto_generator_every_seconds`
+
+## Use the confidence threshold based upload
+
+When the `auto_generator` is set to `False` images will be uploaded according to the value in `p_value`
+
+## Preparation of dependencies
+
+Install the needed dependencies
+
+```shell
+sudo apt install cmake
+sudo apt install g++
+sudo apt install python3-pip
+sudo apt install python3.12-venv
+```
+
+Change into the directory created for the project if you're not already there.
+
+```shell
+cd sclbl-integration-sdk/
+```
+
+Prepare the *build* directory in the project directory, and switch to the build directory.
+
+```shell
+mkdir -p build
+cd build
+```
+
+Set up a python virtual environment in the newly created build directory (on recent ubuntu servers this is required).
+
+```shell
+python3 -m venv integrationsdk
+source integrationsdk/bin/activate
+```
+
+## (optionally) Remove other postprocessors for compilation
+
+Edit the `CMakelist.txt` to disable all but the external postprocessor.
+
+```shell
+nano ../CMakeLists.txt
+```
+
+It should look similar to this
+
+```shell
+cmake_minimum_required(VERSION 3.10.2)
+
+project(sclbl-integration-examples)
+
+# Add Scailable C Utilities for all subprojects
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sclbl-utilities)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/sclbl-utilities/include)
+
+# Add Edge Impulse Postprocessor Python project
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/postprocessor-python-edgeimpulse-example)
+
+# Add installation option
+install(TARGETS
+    DESTINATION /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+)
+install(PROGRAMS
+    ${CMAKE_CURRENT_BINARY_DIR}/postprocessor-python-edgeimpulse-example/postprocessor-python-edgeimpulse-example
+    DESTINATION /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+)
+```
+
+## Compile the postprocessor in python
+
+Build the postprocessor, while in the created *build* directory. This may take a while, depending on the speed of your system.
+
+```shell
+cmake ..
+make
+```
+
+## Install the postprocessor
+
+Once compiled, copy the executable to an accessible directory.
+
+A convenience directory within the Edge AI Manager installation is created for this purpose at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors`.
+
+The application and settings files you add must be readable and executable by the NX AI Edge AI Manager. This can be achieved by running:
 
 ```
 sudo chmod -R 777 /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors
 ```
 
+Install the postprocessor automatically with the cmake command, also from within the *build* directory.
+
+```shell
+cmake --build . --target install
+```
+
 ## Defining the postprocessor
 
-Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/external_postprocessors.json` and add the details of your postprocessor to the root object of that file. For example: 
+Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/external_postprocessors.json` and add the details of your postprocessor to the root object of that file. For example:
 
 ``` json
 {
@@ -95,13 +216,21 @@ sudo service networkoptix-metavms-mediaserver restart
 
 You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
 
-```
+```shell
 sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
 ```
 
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
+
+## Output logging
+
+There is an output log where the uploads can be tracked in real time from the server.
+
+```shell
+tail -f /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.image.log
+```
 
 # Licence
 

--- a/postprocessor-python-image-example/plugin.image.ini.example
+++ b/postprocessor-python-image-example/plugin.image.ini.example
@@ -1,0 +1,2 @@
+[common]
+debug_level=INFO

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -26,7 +26,7 @@ import communication_utils
 
 # The name of the postprocessor.
 # This is used to match the definition of the postprocessor with routing.
-Postprocessor_Name = "Python-Example-Postprocessor"
+Postprocessor_Name = "Python-Image-Example-Postprocessor"
 
 # The socket this postprocessor will listen on.
 # This is always given as the first argument when the process is started

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -19,7 +19,7 @@ LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',
                     filename=LOG_FILE, filemode="w")
-logging.debug("EXAMPLE PLUGIN: Initializing plugin")
+logging.debug("IMAGE EXAMPLE PLUGIN: Initializing plugin")
 
 import communication_utils
 
@@ -59,13 +59,13 @@ def main():
             image_header = communication_utils.receiveMessageOverConnection(connection)
         except socket.timeout:
             # Did not receive image header
-            logging.debug("EXAMPLE PLUGIN: Did not receive image header. Are the settings correct?")
+            logging.debug("IMAGE EXAMPLE PLUGIN: Did not receive image header. Are the settings correct?")
             continue
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
 
-        logging.debug("EXAMPLE PLUGIN: Unpacked: " + input_object)
+        logging.debug("IMAGE EXAMPLE PLUGIN: Unpacked: " + input_object)
 
         image_header = msgpack.unpackb(image_header)
         print(image_header)
@@ -81,8 +81,8 @@ def main():
             input_object["Counts"] = {}
         input_object["Counts"]["ImageBytesCumalitive"] = cumulative
 
-        logging.debug("EXAMPLE PLUGIN: Received input message: " + input_message)
-        logging.debug("EXAMPLE PLUGIN: Packing: " + input_object)
+        logging.debug("IMAGE EXAMPLE PLUGIN: Received input message: " + input_message)
+        logging.debug("IMAGE EXAMPLE PLUGIN: Packing: " + input_object)
 
         # Write object back to string
         output_message = communication_utils.writeInferenceResults(input_object)
@@ -92,12 +92,12 @@ def main():
 
 
 def signalHandler(sig, _):
-    logging.debug("EXAMPLE PLUGIN: Received interrupt signal: " + str(sig))
+    logging.debug("IMAGE EXAMPLE PLUGIN: Received interrupt signal: " + str(sig))
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    logging.debug("EXAMPLE PLUGIN: Input parameters: " + str(sys.argv))
+    logging.debug("IMAGE EXAMPLE PLUGIN: Input parameters: " + str(sys.argv))
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -3,12 +3,24 @@ import os
 import sys
 import socket
 import signal
+import logging
 from PIL import Image
 import msgpack
 
 # Add the sclbl-utilities python utilities
 script_location = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(script_location, "../sclbl-utilities/python-utilities"))
+
+# Set up logging
+LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
+            "nxai_plugin/nxai_manager/etc/plugin.log")
+
+
+# Initialize plugin and logging, script makes use of INFO and DEBUG levels
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',
+                    filename=LOG_FILE, filemode="w")
+logging.debug("EXAMPLE PLUGIN: Initializing plugin")
+
 import communication_utils
 
 # The name of the postprocessor.
@@ -30,7 +42,6 @@ def parseImageFromSHM(shm_key: int, width: int, height: int, channels: int):
 
     return cumulative
 
-
 def main():
     # Start socket listener to receive messages from NXAI runtime
     server = communication_utils.startUnixSocketServer(Postprocessor_Socket_Path)
@@ -48,15 +59,13 @@ def main():
             image_header = communication_utils.receiveMessageOverConnection(connection)
         except socket.timeout:
             # Did not receive image header
-            print(
-                "EXAMPLE PLUGIN: Did not receive image header. Are the settings correct?"
-            )
+            logging.debug("EXAMPLE PLUGIN: Did not receive image header. Are the settings correct?")
             continue
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
 
-        print("Unpacked ", input_object)
+        logging.debug("EXAMPLE PLUGIN: Unpacked: " + input_object)
 
         image_header = msgpack.unpackb(image_header)
         print(image_header)
@@ -72,9 +81,8 @@ def main():
             input_object["Counts"] = {}
         input_object["Counts"]["ImageBytesCumalitive"] = cumulative
 
-        print("EXAMPLE PLUGIN: Received input message: ", input_message)
-
-        print("Packing ", input_object)
+        logging.debug("EXAMPLE PLUGIN: Received input message: " + input_message)
+        logging.debug("EXAMPLE PLUGIN: Packing: " + input_object)
 
         # Write object back to string
         output_message = communication_utils.writeInferenceResults(input_object)
@@ -84,16 +92,19 @@ def main():
 
 
 def signalHandler(sig, _):
-    print("EXAMPLE PLUGIN: Received interrupt signal: ", sig)
+    logging.debug("EXAMPLE PLUGIN: Received interrupt signal: " + str(sig))
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    print("EXAMPLE PLUGIN: Input parameters: ", sys.argv)
+    logging.debug("EXAMPLE PLUGIN: Input parameters: " + str(sys.argv))
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]
     # Handle interrupt signals
     signal.signal(signal.SIGINT, signalHandler)
     # Start program
-    main()
+    try:
+        main()
+    except Exception as e:
+        logging.error(e, exc_info=True)

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.join(script_location, "../sclbl-utilities/python-utiliti
 
 # Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
-            "nxai_plugin/nxai_manager/etc/plugin.image.log")
+            "nxai_plugin/nxai_manager/etc/plugin.log")
 
 
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -37,7 +37,7 @@ Postprocessor_Name = "Python-Image-Example-Postprocessor"
 # The socket this postprocessor will listen on.
 # This is always given as the first argument when the process is started
 # But it can be manually defined as well, as long as it is the same as the socket path in the runtime settings
-Postprocessor_Socket_Path = "/tmp/python-example-postprocessor.sock"
+Postprocessor_Socket_Path = "/tmp/python-image-postprocessor.sock"
 
 
 def parseImageFromSHM(shm_key: int, width: int, height: int, channels: int):

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -3,8 +3,14 @@ import os
 import sys
 import socket
 import signal
-from pprint import pformat
 import logging
+import io
+import time
+from pprint import pformat
+import msgpack
+import struct
+from math import prod
+from datetime import datetime
 from PIL import Image
 import msgpack
 

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -90,12 +90,13 @@ def main():
 
         try:
             input_message, connection = communication_utils.waitForSocketMessage(server)
+            logger.debug("Received input message")
+            formatted_input_message = pformat(input_message)
+            logger.debug(f'Input message: :\n\n{formatted_input_message}\n\n')
+
         except socket.timeout:
             # Request timed out. Continue waiting
             continue
-
-        formatted_input_message = pformat(input_message)
-        logger.debug(f'Received input message: :\n\n{formatted_input_message}\n\n')
 
         # Since we're also expecting an image, receive the image header
         try:
@@ -107,7 +108,6 @@ def main():
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
-
         formatted_unpacked_object = pformat(input_object)
         logger.debug(f'Unpacked:\n\n{formatted_unpacked_object}\n\n')
 
@@ -128,7 +128,7 @@ def main():
         input_object["Counts"]["ImageBytesCumalitive"] = cumulative
 
         formatted_packed_object = pformat(input_object)
-        logger.debug(f'Packing:\n\n{formatted_packed_object}\n\n')
+        logger.info(f'Returning packed object:\n\n{formatted_packed_object}\n\n')
 
         # Write object back to string
         output_message = communication_utils.writeInferenceResults(input_object)
@@ -138,7 +138,7 @@ def main():
 
 
 def signalHandler(sig, _):
-    logger.debug("Received interrupt signal: " + str(sig))
+    logger.info("Received interrupt signal: " + str(sig))
     sys.exit(0)
 
 
@@ -149,7 +149,7 @@ if __name__ == "__main__":
     ## read configuration file if it's available
     config()
 
-    logger.info("Initializing example plugin")
+    logger.info("Initializing image plugin")
     logger.debug("Input parameters: " + str(sys.argv))
 
     # Parse input arguments

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -14,7 +14,7 @@ sys.path.append(os.path.join(script_location, "../sclbl-utilities/python-utiliti
 
 # Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
-            "nxai_plugin/nxai_manager/etc/plugin.log")
+            "nxai_plugin/nxai_manager/etc/plugin.image.log")
 
 
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -76,7 +76,9 @@ def main():
         logging.debug(f'IMAGE EXAMPLE PLUGIN: Unpacked:\n\n{formatted_unpacked_object}\n\n')
 
         image_header = msgpack.unpackb(image_header)
-        print(image_header)
+        formatted_image_object = pformat(image_header)
+        logging.debug(f'IMAGE EXAMPLE PLUGIN: image_header:\n\n{formatted_image_object}\n\n')
+
         cumulative = parseImageFromSHM(
             image_header["SHMKey"],
             image_header["Width"],

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -109,11 +109,11 @@ def main():
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
         formatted_unpacked_object = pformat(input_object)
-        logger.debug(f'Unpacked:\n\n{formatted_unpacked_object}\n\n')
+        logger.info(f'Unpacked input image:\n\n{formatted_unpacked_object}\n\n')
 
         image_header = msgpack.unpackb(image_header)
         formatted_image_object = pformat(image_header)
-        logger.debug(f'image_header:\n\n{formatted_image_object}\n\n')
+        logger.debug(f'Image header:\n\n{formatted_image_object}\n\n')
 
         cumulative = parseImageFromSHM(
             image_header["SHMKey"],
@@ -122,10 +122,23 @@ def main():
             image_header["Channels"],
         )
 
+        # add image header to output
+        if "IH" not in input_object:
+            input_object["IH"] = {}
+        input_object["IH"]["SHMKey"] = image_header["SHMKey"]
+        input_object["IH"]["Width"] = image_header["Width"]
+        input_object["IH"]["Height"] = image_header["Height"]
+        input_object["IH"]["Channels"] = image_header["Channels"]
+
         # Add extra bbox
+        if "BBoxes_xyxy" not in input_object:
+            input_object["BBoxes_xyxy"] = {}
+        input_object["BBoxes_xyxy"]["test"] = [100.0, 100.0, 200.0, 200.0]
+
+        # Add Counts
         if "Counts" not in input_object:
             input_object["Counts"] = {}
-        input_object["Counts"]["ImageBytesCumalitive"] = cumulative
+        input_object["Counts"]["ImageBytesCumulative"] = cumulative
 
         formatted_packed_object = pformat(input_object)
         logger.info(f'Returning packed object:\n\n{formatted_packed_object}\n\n')

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -86,11 +86,16 @@ def main():
     # Wait for messages in a loop
     while True:
         # Wait for input message from runtime
+        logger.debug("Waiting for input message")
+
         try:
             input_message, connection = communication_utils.waitForSocketMessage(server)
         except socket.timeout:
             # Request timed out. Continue waiting
             continue
+
+        formatted_input_message = pformat(input_message)
+        logger.debug(f'Received input message: :\n\n{formatted_input_message}\n\n')
 
         # Since we're also expecting an image, receive the image header
         try:
@@ -121,8 +126,6 @@ def main():
         if "Counts" not in input_object:
             input_object["Counts"] = {}
         input_object["Counts"]["ImageBytesCumalitive"] = cumulative
-
-        logger.debug("Received input message: " + input_message)
 
         formatted_packed_object = pformat(input_object)
         logger.debug(f'Packing:\n\n{formatted_packed_object}\n\n')

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -42,7 +42,7 @@ Postprocessor_Name = "Python-Image-Example-Postprocessor"
 Postprocessor_Socket_Path = "/tmp/python-image-postprocessor.sock"
 
 
-def parseImageFromSHM(shm_key: int, width: int, height: int, channels: int):
+def parse_image_from_shm(shm_key: int, width: int, height: int, channels: int):
     image_data = communication_utils.read_shm(shm_key)
 
     cumulative = 0
@@ -60,7 +60,7 @@ def config():
         configuration.read(CONFIG_FILE)
 
         configured_log_level = configuration.get('common', 'debug_level', fallback = 'INFO')
-        setLogLevel(configured_log_level)
+        set_log_level(configured_log_level)
 
         for section in configuration.sections():
             logger.info('config section: ' + section)
@@ -73,11 +73,16 @@ def config():
     logger.debug('Read configuration done')
 
 
-def setLogLevel(level):
+def set_log_level(level):
     try:
         logger.setLevel(level)
     except Exception as e:
         logger.error(e, exc_info=True)
+
+
+def signal_handler(sig, _):
+    logger.info("Received interrupt signal: " + str(sig))
+    sys.exit(0)
 
 
 def main():
@@ -115,7 +120,7 @@ def main():
         formatted_image_object = pformat(image_header)
         logger.debug(f'Image header:\n\n{formatted_image_object}\n\n')
 
-        cumulative = parseImageFromSHM(
+        cumulative = parse_image_from_shm(
             image_header["SHMKey"],
             image_header["Width"],
             image_header["Height"],
@@ -150,11 +155,6 @@ def main():
         communication_utils.sendMessageOverConnection(connection, output_message)
 
 
-def signalHandler(sig, _):
-    logger.info("Received interrupt signal: " + str(sig))
-    sys.exit(0)
-
-
 if __name__ == "__main__":
     ## initialize the logger
     logger = logging.getLogger(__name__)
@@ -169,7 +169,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]
     # Handle interrupt signals
-    signal.signal(signal.SIGINT, signalHandler)
+    signal.signal(signal.SIGINT, signal_handler)
     # Start program
     try:
         main()

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -3,6 +3,7 @@ import os
 import sys
 import socket
 import signal
+from pprint import pformat
 import logging
 from PIL import Image
 import msgpack
@@ -65,7 +66,8 @@ def main():
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
 
-        logging.debug("IMAGE EXAMPLE PLUGIN: Unpacked: " + input_object)
+        formatted_unpacked_object = pformat(input_object)
+        logging.debug(f'IMAGE EXAMPLE PLUGIN: Unpacked:\n\n{formatted_unpacked_object}\n\n')
 
         image_header = msgpack.unpackb(image_header)
         print(image_header)
@@ -82,7 +84,9 @@ def main():
         input_object["Counts"]["ImageBytesCumalitive"] = cumulative
 
         logging.debug("IMAGE EXAMPLE PLUGIN: Received input message: " + input_message)
-        logging.debug("IMAGE EXAMPLE PLUGIN: Packing: " + input_object)
+
+        formatted_packed_object = pformat(input_object)
+        logging.debug(f'IMAGE EXAMPLE PLUGIN: Packing:\n\n{formatted_packed_object}\n\n')
 
         # Write object back to string
         output_message = communication_utils.writeInferenceResults(input_object)

--- a/postprocessor-python-image-example/postprocessor-python-image-example.py
+++ b/postprocessor-python-image-example/postprocessor-python-image-example.py
@@ -56,16 +56,16 @@ def config():
     logger.info('Reading configuration from:' + CONFIG_FILE)
 
     try:
-        config = configparser.ConfigParser()
-        config.read(CONFIG_FILE)
+        configuration = configparser.ConfigParser()
+        configuration.read(CONFIG_FILE)
 
-        configured_log_level = config.get('common', 'debug_level', fallback = 'INFO')
+        configured_log_level = configuration.get('common', 'debug_level', fallback = 'INFO')
         setLogLevel(configured_log_level)
 
-        for section in config.sections():
+        for section in configuration.sections():
             logger.info('config section: ' + section)
-            for key in config[section]:
-                logger.info('config key: ' + key + ' = ' + config[section][key])
+            for key in configuration[section]:
+                logger.info('config key: ' + key + ' = ' + configuration[section][key])
 
     except Exception as e:
         logger.error(e, exc_info=True)

--- a/postprocessor-python-noresponse-example/CMakeLists.txt
+++ b/postprocessor-python-noresponse-example/CMakeLists.txt
@@ -3,5 +3,5 @@ add_custom_target(postprocessor-python-noresponse-example ALL
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND pip install -r ../sclbl-utilities/python-utilities/requirements.txt
     COMMAND pip install -r requirements.txt
-    COMMAND pyinstaller postprocessor-python-noresponse-example.py --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
+    COMMAND pyinstaller postprocessor-python-noresponse-example.py --clean --onefile --workpath ${CMAKE_CURRENT_BINARY_DIR}/build --distpath ${CMAKE_CURRENT_BINARY_DIR} --paths=${CMAKE_SOURCE_DIR}/sclbl-utilities/python-utilities -y
 )

--- a/postprocessor-python-noresponse-example/README.md
+++ b/postprocessor-python-noresponse-example/README.md
@@ -19,7 +19,7 @@ The incoming MessagePack message follows a specific schema. If the message is al
 {
     "Timestamp": <Timestamp>,
     "Width": <Width>,
-    "Height": <Hieght>,
+    "Height": <Height>,
     "InputIndex": <Index>,
     "Counts": {
         <"Class Name">: <Class Count>

--- a/postprocessor-python-noresponse-example/README.md
+++ b/postprocessor-python-noresponse-example/README.md
@@ -70,7 +70,7 @@ git pull --recurse-submodules
 
 ## Configuration of example postprocessor
 
-Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.noresponse.ini` and add some overrides for the configuration.
+Create a [configuration file](plugin.noresponse.ini.example) at `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/etc/plugin.noresponse.ini` and add some overrides for the configuration.
 
 This plugin only supports changing the debug level between DEBUG, INFO, WARNING, ERROR and CRITICAL
 

--- a/postprocessor-python-noresponse-example/README.md
+++ b/postprocessor-python-noresponse-example/README.md
@@ -74,6 +74,20 @@ This tells the Edge AI Manager about the postprocessor:
 
 The socket path is always given as the first command line argument when the application is started. It is therefore best practice for the external postprocessor application to read its socket path from here, instead of defining the data twice.
 
+## Restarting the server
+
+Finally, to (re)load your new postprocessor, make sure to restart the NX Server with:
+
+```shell
+sudo service networkoptix-metavms-mediaserver restart
+```
+
+You also want to make sure the postprocessor can be used by the NX AI Manager (this is the mostly same command as earlier)
+
+```
+sudo chmod -R a+x /opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/
+```
+
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.

--- a/postprocessor-python-noresponse-example/README.md
+++ b/postprocessor-python-noresponse-example/README.md
@@ -55,7 +55,7 @@ Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugin
         {
             "Name":"NoResponse-Example-Postprocessor",
             "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-example",
-            "SocketPath":"/tmp/example-postprocessor.sock",
+            "SocketPath":"/tmp/python-noresponse-postprocessor.sock",
             "ReceiveInputTensor": 0,
             "ReceiveBinaryData": false,
             "NoResponse": true
@@ -77,7 +77,6 @@ The socket path is always given as the first command line argument when the appl
 ## Selecting to the postprocessor
 
 If the postprocessor is defined correctly, its name should appear in the list of postprocessors in the NX Plugin settings. If it is selected in the plugin settings then the Edge AI Runtime will send data to the postprocessor and wait for its output.
-
 
 # Licence
 

--- a/postprocessor-python-noresponse-example/README.md
+++ b/postprocessor-python-noresponse-example/README.md
@@ -54,7 +54,7 @@ Create a configuration file at `/opt/networkoptix-metavms/mediaserver/bin/plugin
     "externalPostprocessors": [
         {
             "Name":"NoResponse-Example-Postprocessor",
-            "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-example",
+            "Command":"/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/postprocessor-python-noresponse-example",
             "SocketPath":"/tmp/python-noresponse-postprocessor.sock",
             "ReceiveInputTensor": 0,
             "ReceiveBinaryData": false,

--- a/postprocessor-python-noresponse-example/plugin.noresponse.ini.example
+++ b/postprocessor-python-noresponse-example/plugin.noresponse.ini.example
@@ -1,0 +1,2 @@
+[common]
+debug_level=INFO

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -12,7 +12,7 @@ import communication_utils
 
 # Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
-            "nxai_plugin/nxai_manager/etc/plugin.noresponse.log")
+            "nxai_plugin/nxai_manager/etc/plugin.log")
 
 
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -2,8 +2,14 @@ import os
 import sys
 import socket
 import signal
-from pprint import pformat
 import logging
+import io
+import time
+from pprint import pformat
+import msgpack
+import struct
+from math import prod
+from datetime import datetime
 
 # Add the sclbl-utilities python utilities
 script_location = os.path.dirname(os.path.realpath(__file__))

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -2,6 +2,7 @@ import os
 import sys
 import socket
 import signal
+from pprint import pformat
 import logging
 
 # Add the sclbl-utilities python utilities
@@ -55,20 +56,21 @@ def main():
             # Request timed out. Continue waiting
             continue
 
-        logging.debug("NORESPONSE EXAMPLE PLUGIN: Received input message: ", input_message)
+        logging.debug("NORESPONSE EXAMPLE PLUGIN: Received input message: " + input_message)
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
 
-        logging.debug("NORESPONSE EXAMPLE PLUGIN: Unpacked ", input_object)
+        formatted_unpacked_object = pformat(input_object)
+        logging.debug(f'NORESPONSE EXAMPLE PLUGIN: Unpacked:\n\n{formatted_unpacked_object}\n\n')
 
 def signalHandler(sig, _):
-    logging.debug("NORESPONSE EXAMPLE PLUGIN: Received interrupt signal: ", sig)
+    logging.debug("NORESPONSE EXAMPLE PLUGIN: Received interrupt signal: " + str(sig))
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    logging.debug("NORESPONSE EXAMPLE PLUGIN: Input parameters: ", sys.argv)
+    logging.debug("NORESPONSE EXAMPLE PLUGIN: Input parameters: " + str(sys.argv))
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -22,7 +22,7 @@ logging.debug("NORESPONSE EXAMPLE PLUGIN: Initializing plugin")
 
 # The name of the postprocessor.
 # This is used to match the definition of the postprocessor with routing.
-Postprocessor_Name = "Python-Example-Postprocessor"
+Postprocessor_Name = "Python-NoResponse-Example-Postprocessor"
 
 # The socket this postprocessor will listen on.
 # This is always given as the first argument when the process is started

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -12,7 +12,7 @@ import communication_utils
 
 # Set up logging
 LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
-            "nxai_plugin/nxai_manager/etc/plugin.log")
+            "nxai_plugin/nxai_manager/etc/plugin.noresponse.log")
 
 
 # Initialize plugin and logging, script makes use of INFO and DEBUG levels

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -5,13 +5,7 @@ import signal
 import logging
 import logging.handlers
 import configparser
-import io
-import time
 from pprint import pformat
-import msgpack
-import struct
-from math import prod
-from datetime import datetime
 
 # Add the sclbl-utilities python utilities
 script_location = os.path.dirname(os.path.realpath(__file__))
@@ -31,7 +25,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - no
 
 # The name of the postprocessor.
 # This is used to match the definition of the postprocessor with routing.
-Postprocessor_Name = "Python-NoResponse-Example-Postprocessor"
+Postprocessor_Name = "Python-NoResponse-Postprocessor"
 
 # The socket this postprocessor will listen on.
 # This is always given as the first argument when the process is started
@@ -88,11 +82,12 @@ def main():
         # Wait for input message from runtime
         try:
             input_message, _ = communication_utils.waitForSocketMessage(server)
+            logging.debug("Received input message")
+            formatted_input_message = pformat(input_message)
+            logger.debug(f'Input message: :\n\n{formatted_input_message}\n\n')
         except socket.timeout:
             # Request timed out. Continue waiting
             continue
-
-        logging.debug("Received input message")
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -54,7 +54,7 @@ def config():
         configuration.read(CONFIG_FILE)
 
         configured_log_level = configuration.get('common', 'debug_level', fallback = 'INFO')
-        setLogLevel(configured_log_level)
+        set_log_level(configured_log_level)
 
         for section in configuration.sections():
             logger.info('config section: ' + section)
@@ -67,11 +67,16 @@ def config():
     logger.debug('Read configuration done')
 
 
-def setLogLevel(level):
+def set_log_level(level):
     try:
         logger.setLevel(level)
     except Exception as e:
         logger.error(e, exc_info=True)
+
+
+def signal_handler(sig, _):
+    logging.debug("Received interrupt signal: " + str(sig))
+    sys.exit(0)
 
 
 def main():
@@ -100,11 +105,6 @@ def main():
         logging.info(f'Unpacked object:\n\n{formatted_unpacked_object}\n\n')
 
 
-def signalHandler(sig, _):
-    logging.debug("Received interrupt signal: " + str(sig))
-    sys.exit(0)
-
-
 if __name__ == "__main__":
     ## initialize the logger
     logger = logging.getLogger(__name__)
@@ -119,7 +119,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]
     # Handle interrupt signals
-    signal.signal(signal.SIGINT, signalHandler)
+    signal.signal(signal.SIGINT, signal_handler)
 
     # Start program
     try:

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -2,11 +2,22 @@ import os
 import sys
 import socket
 import signal
+import logging
 
 # Add the sclbl-utilities python utilities
 script_location = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(script_location, "../sclbl-utilities/python-utilities"))
 import communication_utils
+
+# Set up logging
+LOG_FILE = ("/opt/networkoptix-metavms/mediaserver/bin/plugins/"
+            "nxai_plugin/nxai_manager/etc/plugin.log")
+
+
+# Initialize plugin and logging, script makes use of INFO and DEBUG levels
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',
+                    filename=LOG_FILE, filemode="w")
+logging.debug("NORESPONSE EXAMPLE PLUGIN: Initializing plugin")
 
 # The name of the postprocessor.
 # This is used to match the definition of the postprocessor with routing.
@@ -44,20 +55,20 @@ def main():
             # Request timed out. Continue waiting
             continue
 
-        print("EXAMPLE PLUGIN: Received input message: ", input_message)
+        logging.debug("NORESPONSE EXAMPLE PLUGIN: Received input message: ", input_message)
 
         # Parse input message
         input_object = communication_utils.parseInferenceResults(input_message)
 
-        print("Unpacked ", input_object)
+        logging.debug("NORESPONSE EXAMPLE PLUGIN: Unpacked ", input_object)
 
 def signalHandler(sig, _):
-    print("EXAMPLE PLUGIN: Received interrupt signal: ", sig)
+    logging.debug("NORESPONSE EXAMPLE PLUGIN: Received interrupt signal: ", sig)
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    print("EXAMPLE PLUGIN: Input parameters: ", sys.argv)
+    logging.debug("NORESPONSE EXAMPLE PLUGIN: Input parameters: ", sys.argv)
     # Parse input arguments
     if len(sys.argv) > 1:
         Postprocessor_Socket_Path = sys.argv[1]

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -77,9 +77,13 @@ def setLogLevel(level):
 def main():
     # Start socket listener to receive messages from NXAI runtime
     server = communication_utils.startUnixSocketServer(Postprocessor_Socket_Path)
+
+    logging.debug("Starting main" + str(Postprocessor_Socket_Path))
     # Wait for messages in a loop
     while True:
         # Wait for input message from runtime
+        logging.debug("Starting loop")
+
         try:
             input_message, _ = communication_utils.waitForSocketMessage(server)
             logging.debug("Received input message")
@@ -93,7 +97,7 @@ def main():
         input_object = communication_utils.parseInferenceResults(input_message)
 
         formatted_unpacked_object = pformat(input_object)
-        logging.info(f'Unpacked:\n\n{formatted_unpacked_object}\n\n')
+        logging.info(f'Unpacked object:\n\n{formatted_unpacked_object}\n\n')
 
 
 def signalHandler(sig, _):

--- a/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
+++ b/postprocessor-python-noresponse-example/postprocessor-python-noresponse-example.py
@@ -33,7 +33,7 @@ Postprocessor_Name = "Python-NoResponse-Example-Postprocessor"
 # The socket this postprocessor will listen on.
 # This is always given as the first argument when the process is started
 # But it can be manually defined as well, as long as it is the same as the socket path in the runtime settings
-Postprocessor_Socket_Path = "/tmp/python-example-postprocessor.sock"
+Postprocessor_Socket_Path = "/tmp/python-noresponse-postprocessor.sock"
 
 # Data Types
 # 1:  //FLOAT


### PR DESCRIPTION
- [x] postprocessor-python-example with added config and logging
- [x] postprocessor-python-image-example with added config and logging
- [x] postprocessor-python-noresponse-example with added config and logging
- [x] postprocessor-python-edgeimpulse-example with added config and logging
- [x] postprocessor-cloud-inference-example with added config and logging
- [x] example with all postprocessors in root readme.md for `/opt/networkoptix-metavms/mediaserver/bin/plugins/nxai_plugin/nxai_manager/postprocessors/external_postprocessors.json` 
- [x] All readme.md files complete for python code
- [x] Example config files in repo
- [x] Reorder python structure with main on the same place everywhere

